### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: build
 
 .PHONY: invalidate-cppcov
 invalidate-cppcov:
+	touch test.gcno
 	find . -name "*.gcno" -print0 | xargs -0 rm
 
 .PHONY: build
@@ -31,7 +32,7 @@ clean: clean-coverage
 
 .PHONY: test
 test: build
-	pytest -n auto
+	pytest # '-n auto' does not work anymore
 
 .PHONY: pycov
 pycov: clean-coverage-pycov


### PR DESCRIPTION
Ensure successful 'make test'

For me 'make test' always resulted in errors even before the actual testing started as the "rm" command was not fed with files to delete. Moreover, the "-n auto" option seems outdated, at least in accordance with 'man pytest '

Thus 2 minor corrections proposed.