### PR TITLE
docs: remove defusedxml as a requirement

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -121,7 +121,6 @@ pikepdf requires:
 -   `pybind11 <https://github.com/pybind/pybind11>`_
 -   libqpdf |qpdf-version| or higher from the
     `QPDF <https://github.com/qpdf/qpdf>`_ project.
--   defusedxml - Python package
 
 On Linux the library and headers for libqpdf must be installed because pikepdf
 compiles code against it and links to it.


### PR DESCRIPTION
defusedxml was dropped in v1.3.0.