### PR TITLE
Update copyright information reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ pikepdf is provided under the [Mozilla Public License 2.0](https://www.mozilla.o
 
 [Informally](https://www.mozilla.org/en-US/MPL/2.0/FAQ/), MPL 2.0 is a not a "viral" license. It may be combined with other work, including commercial software. However, you must disclose your modifications *to pikepdf* in source code form. In other works, fork this repository on GitHub or elsewhere and commit your contributions there, and you've satisfied your obligations. MPL 2.0 is compatible with the GPL and LGPL - see the [guidelines](https://www.mozilla.org/en-US/MPL/2.0/combining-mpl-and-gpl/) for notes on use in GPL.
 
-The `tests/resources/copyright` file describes licensing terms for the test suite and the provenance of test resources.
+The [`debian/copyright`](/debian/copyright) file describes licensing terms for the test suite and the provenance of test resources.


### PR DESCRIPTION
The licensing terms were moved in 6c6df5c6406554a19045e4178229ca1657c73954.

This commit updates the path in README.md to match the new location.