### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -36,7 +36,7 @@ dictionaries.
 
     In [1]: pdfimage = PdfImage(rawimage)
 
-    In [1]: pdfimage
+    In [1]: type(pdfimage)
 
 In Jupyter (or IPython with a suitable backend) the image will be
 displayed.
@@ -84,7 +84,7 @@ You can also retrieve the image as a Pillow image:
 
 .. ipython::
 
-    In [1]: pdfimage.as_pil_image()
+    In [1]: type(pdfimage.as_pil_image())
 
 Another way to view the image is using Pillow's ``Image.show()`` method.
 

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ if 'bsd' in sys.platform:
 ext_modules = [
     Extension(
         'pikepdf._qpdf',
-        glob('src/qpdf/*.cpp'),
-        depends=glob('src/qpdf/*.h'),
+        sorted(glob('src/qpdf/*.cpp')),
+        depends=sorted(glob('src/qpdf/*.h')),
         include_dirs=[
             # Path to pybind11 headers
             get_pybind_include(),


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that pikepdf could not be built reproducibly. This was due to two reasons:

a) The documentation included tutorial/walthrough like output like so:

    <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=1000x1520 at 0x7F04BAC72B90>

… where the `0x7F04BAC72B90` part is non-determinstic and thus varies between builds.

b) The `.cpp` input files were compiled/linked in an order that was determined by their layout on the filesystem which is, at least on UNIX systems, non-deterministic.

This PR addresses both these issues.

It was orginally filed in Debian as [#950138](https://bugs.debian.org/950138).