### PR TITLE
Fix compilation on GCC 5

### DIFF
--- a/src/qpdf/object_convert.cpp
+++ b/src/qpdf/object_convert.cpp
@@ -116,7 +116,7 @@ QPDFObjectHandle objecthandle_encode(const py::handle handle)
         return QPDFObjectHandle::newInteger(as_int);
     } else if (py::isinstance<py::float_>(handle)) {
         auto as_double = handle.cast<double>();
-        if (! isfinite(as_double))
+        if (! std::isfinite(as_double))
             throw py::value_error("Can't convert NaN or Infinity to PDF real number");
         return QPDFObjectHandle::newReal(as_double);
     }


### PR DESCRIPTION
When compiling with GCC 5.5.0, the build fails with the following error:

```
gcc-5 -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DVERSION_INFO="1.18.0" -I/tmp/pip-build-env-7qgayzrg/overlay/lib/python3.6/site-packages/pybind11/include -I/usr/include/python3.6m -c src/qpdf/object_convert.cpp -o build/temp.linux-x86_64-3.6/src/qpdf/object_convert.o -std=c++14 -fvisibility=hidden
src/qpdf/object_convert.cpp: In function ‘QPDFObjectHandle objecthandle_encode(pybind11::handle)’:
src/qpdf/object_convert.cpp:119:33: error: ‘isfinite’ was not declared in this scope
         if (! isfinite(as_double))
                                 ^
src/qpdf/object_convert.cpp:119:33: note: suggested alternative:
In file included from src/qpdf/object_convert.cpp:15:0:
/usr/include/c++/5/cmath:604:5: note:   ‘std::isfinite’
     isfinite(_Tp __x)
     ^
error: command 'gcc-5' failed with exit status 1
----------------------------------------
ERROR: Failed building wheel for pikepdf
```

Ubuntu 18.04.5
Python 3.6.9
gcc-5 (Ubuntu 5.5.0-12ubuntu1) 5.5.0 20171010

This is fixed by using `std::isfinite()` instead. Apparently, `isfinite()` is not in the global namespace in the GCC C++ library for GCC 5, as explained in more detail at erincatto/Box2D#509.