### PR TITLE
Fix test for qpdf 10.2

### DIFF
--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -287,7 +287,7 @@ class TestRepr:
         )
         expected = """\
             pikepdf.Dictionary({
-                "/Array": [ 1, 2, Decimal('3.140000') ],
+                "/Array": [ 1, 2, Decimal('3.14') ],
                 "/Boolean": True,
                 "/Dictionary": {
                     "/Color": "Red"


### PR DESCRIPTION
In qpdf 10.2, trailing zeroes are stripped from the representation of real numbers. You may want to code this test to work either way. With this change, pikepdf's tests pass with qpdf 10.2, which I am planning on releasing today.