### PR TITLE
Fix mingw64 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import sysconfig
 from glob import glob
 from os import environ
 from os.path import dirname, join
@@ -51,6 +52,9 @@ if sys.platform == 'cygwin':
     # On cygwin, use gnu++14 instead of c++14
     eca = ext_modules[0].extra_compile_args
     eca[eca.index('-std=c++14')] = '-std=gnu++14'
+
+if sysconfig.get_platform() == 'mingw':
+    ext_modules[0].extra_compile_args = ['-std=c++14']
 
 # Debug build
 # ext_modules[0].extra_compile_args.append('-g3')


### PR DESCRIPTION
Pybind11Extension add "/EHsc /bigobj /std:c++14" flags. This is good for
Visual C++ but not for Mingw.