### PR TITLE
Minor corrections to documentation

### DIFF
--- a/docs/topics/objects.rst
+++ b/docs/topics/objects.rst
@@ -14,7 +14,7 @@ a pikepdf user.
 The simplest types in PDFs are directly represented as Python types: ``int``,
 ``bool``, and ``None`` stand for PDF integers, booleans and the "null".
 :class:`~decimal.Decimal` is used for floating point numbers in PDFs. If a
-value in a PDF is assigned to a Python ``float``, pikepdf will convert it to
+value in a PDF is assigned a Python ``float``, pikepdf will convert it to
 ``Decimal``.
 
 Types that are not directly convertible to Python are represented as
@@ -90,5 +90,5 @@ closing a PDF.
 
 When objects are copied from one :class:`pikepdf.Pdf` to another, the
 underlying data is copied immediately into the target. As such it is possible
-to merge hundreds of `Pdf` into one, keeping only a single source and the
-target file open at a time.
+to merge hundreds of `Pdf` into one, keeping only a single source at a time and the
+target file open.

--- a/docs/topics/pages.rst
+++ b/docs/topics/pages.rst
@@ -20,7 +20,7 @@ Let’s continue with ``fourpages.pdf`` from the :ref:`tutorial`.
 Split a PDF into one page PDFs
 ------------------------------
 
-All we need is a new PDF to hold the destination page.
+All we need are new PDFs to hold the destination pages.
 
 .. ipython::
     :verbatim:
@@ -36,7 +36,7 @@ All we need is a new PDF to hold the destination page.
 
     This example will transfer data associated with each page, so
     that every page stands on its own. It will *not* transfer some metadata
-    associated with the PDF as a whole, such the list of bookmarks.
+    associated with the PDF as a whole, such as the list of bookmarks.
 
 .. _mergepdf:
 
@@ -61,7 +61,7 @@ We create an empty ``Pdf`` which will be the container for all the others.
 This code sample is enough to merge most PDFs, but there are some things it
 does not do that a more sophisticated function might do. One could call
 :meth:`pikepdf.Pdf.remove_unreferenced_resources` to remove unreferenced objects
-from the page's ``/Resources`` dictionary. It may also be necessary to chose the
+from the pages' ``/Resources`` dictionaries. It may also be necessary to chose the
 most recent version of all source PDFs. Here is a more sophisticated example:
 
 .. ipython::
@@ -128,7 +128,7 @@ position, bumping everything else ahead.
 
 Copying pages between ``Pdf`` objects will create a shallow copy of the source
 page within the target ``Pdf``, rather than the typical Python behavior of
-creating a reference. As such, modifying ``pdf.pages[-1]`` will not affect
+creating a reference. Therefore modifying ``pdf.pages[-1]`` will not affect
 ``appendix.pages[0]``. (Normally, assigning objects between Python lists creates
 a reference, so that the two objects are identical, ``list[0] is list[1]``.)
 
@@ -250,4 +250,4 @@ Pages information from Root
 
     The internal consistency of the various ``/Page`` and ``/Pages`` is not
     guaranteed when accessed in this manner, and in some PDFs the data structure
-    for these is fairly complex. Use the ``.pages`` interface.
+    for these is fairly complex. Use the ``.pages`` interface instead.

--- a/docs/topics/streams.rst
+++ b/docs/topics/streams.rst
@@ -13,7 +13,7 @@ sometimes called streams.
 Most of the interesting content in a PDF (images and content streams) are
 inside stream objects.
 
-Because the PDF specification unfortunately defines several terms involve the
+Because the PDF specification unfortunately defines several terms that involve the
 word stream, let's attempt to clarify:
 
 .. figure:: /images/28fish.jpg
@@ -43,7 +43,7 @@ content stream
 Form XObject
   A group of images, text and drawing commands that can be rendered elsewhere
   in a PDF as a group. This is often used when a group of objects are needed
-  at different scales or multiple pages. In HTML this is like an ``<svg>``.
+  at different scales or on multiple pages. In HTML this is like an ``<svg>``.
   It is not a fillable PDF form (although a fillable PDF form could involve
   Form XObjects).
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -36,7 +36,7 @@ there is no default constructor since the arguments used for creation and
 opening are different. To make a new empty PDF, use ``Pdf.new()`` not ``Pdf()``.
 
 ``Pdf.open()`` also accepts seekable streams as input, and ``Pdf.save()`` accepts
-streams as output. :class:`pathlib.Path` objects are fully supported anywhere
+streams as output. :class:`pathlib.Path` objects are fully supported wherever
 pikepdf accepts a filename.
 
 Inspecting pages
@@ -62,7 +62,7 @@ How many pages?
 
 pikepdf integrates with IPython and Jupyter's rich object APIs so that you can
 view PDFs, PDF pages, or images within PDF in a IPython window or Jupyter
-notebook. This makes easier it to test visual changes.
+notebook. This makes it easier to test visual changes.
 
 .. ipython::
     :verbatim:
@@ -99,9 +99,9 @@ structure much like a Python ``dict`` or ``attrdict``. The major difference is
 that the keys can only be **names**, and the values can only be PDF types, including
 other dictionaries.
 
-PDF dictionaries are represented as :class:`pikepdf.Dictionary`, and names
-are of type :class:`pikepdf.Name`. A page is just a dictionary with a certain
-required keys and a reference from the document's "page tree". (pikepdf manages
+PDF dictionaries are represented as :class:`pikepdf.Dictionary` objects, and names
+are of type :class:`pikepdf.Name`. A page is just a dictionary with certain
+required keys and a reference to the document's "page tree". (pikepdf manages
 the page tree for you.)
 
 .. ipython::
@@ -143,8 +143,8 @@ keys (``page1['/MediaBox']``).
 By convention, pikepdf uses attribute notation for standard names (the names
 that are normally part of a dictionary, according to the PDF Reference Manual),
 and item notation for names that may not always appear. For example, the images
-belong to a page always appear at ``page.Resources.XObject`` but the name
-of images is arbitrarily chosen by whatever software generates the PDF (``/Im0``,
+belong to a page always appear at ``page.Resources.XObject`` but the names
+of images are arbitrarily chosen by whatever software generates the PDF (``/Im0``,
 in this case). (Whenever expressed as strings, names begin with ``/``.)
 
 .. ipython::


### PR DESCRIPTION
This request provides some minor corrections to the documentation.
Sorry if I misunderstood anything.

I have not corrected the following:

tutorial.rst

line 227+

As in all PDFs, if a user password is set, it will not be possible to
open the PDF without the password. If the owner password is set, changes will
not be permitted with the owner password. If the user password is an empty
string and an owner password is set, the PDF can be viewed by anyone with the
user (or owner) password. PDF viewers only enforce ``pikepdf.Permissions``
restrictions when a PDF is opened with the user password, since the owner may
change anything.

 If the owner password is set, changes will
not be permitted with the owner password.

presumably you mean:

 If the owner password is set, changes will
not be permitted without the owner password.

If the user password is an empty
string and an owner password is set, the PDF can be viewed by anyone with the
user (or owner) password.

presumably you mean:

If the user password is an empty
string and an owner password is set, the PDF can be viewed by anyone without any
user (or owner) password.






