### PR TITLE
Disable parallel compile for Termux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
 from glob import glob
 from os import environ
-from os.path import dirname, join
+from os.path import dirname, isfile, join
 
 from setuptools import find_packages, setup
 
@@ -13,6 +13,9 @@ except ImportError:
 
     ParallelCompile = None
     print("pybind11.setup_helpers NOT loaded - you might need to pip install pybind11")
+
+if sys.platform == "linux" and isfile("/system/bin/app_process"):
+    ParallelCompile = None
 
 extra_includes = []
 extra_library_dirs = []


### PR DESCRIPTION
Parallel compile does not work on Termux because Android does not support sem_open().
See https://github.com/termux/termux-packages/issues/570 for a detailed explanation.
The logic to detect Termux was taken from https://github.com/termux/termux-packages/blob/master/build-package.sh