### PR TITLE
Update comparison: PyPDF2 does have documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This library is similar to PyPDF2 and pdfrw - it provides low level access to PD
 | Modifies PDF/A without breaking PDF/A compliance                    | ✔                                           | ✘                                         | ?                                       |
 | Automatically repairs PDFs with internal errors                     | ✔                                           | ✘                                         | ✘                                       |
 | PDF XMP metadata editing                                            | ✔                                           | read-only                                 | ✘                                       |
-| Documentation                                                       | ✔                                           | ✘                                         | ✔                                       |
+| Documentation                                                       | ✔                                           | ✔                                         | ✔                                     |
 | Integrates with Jupyter and IPython notebooks for rapid development | ✔                                           | ✘                                         | ✘                                       |
 
 


### PR DESCRIPTION
https://pythonhosted.org/PyPDF2/