### PR TITLE
Add license string in metadata (setup.cfg)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = pikepdf
 description = Read and write PDFs with Python, powered by qpdf
+license = MPL 2.0
 license_files =
     LICENSE.txt
     licenses/license.wheel.txt


### PR DESCRIPTION
to prevent `pip3 show pikepdf` from displaying `License: UNKNOWN`
cf. https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#metadata
Note: not tested