### PR TITLE
Update the FreeBSD specific parts of the documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -114,13 +114,13 @@ Installing on FreeBSD
 
 .. code-block:: bash
 
-    pkg install py37-pikepdf
+    pkg install py38-pikepdf
 
 To attempt a manual install, try something like:
 
 .. code-block:: bash
 
-    pkg install python3 py37-lxml py37-pip py37-pybind11 qpdf
+    pkg install python3 py38-lxml py38-pip py38-pybind11 qpdf
     pip install --user pikepdf
 
 This procedure is known to work on FreeBSD 11.3, 12.0, 12.1-RELEASE and


### PR DESCRIPTION
The Python default version was changed from 3.7 to 3.8 at the end of April.  For the new quarterly branch, 2021Q3, Python 3.8 has also been the default version since July.