### PR TITLE
Enable Python 3.10 wheels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This library is similar to PyPDF2 and pdfrw - it provides low level access to PD
 | Based on an existing, mature PDF library                            | QPDF                                        | ✘                                         | ✘                                       |
 | Implementation                                                      | C++ and Python                              | Python                                    | Python                                  |
 | PDF versions supported                                              | 1.1 to 1.7                                  | 1.3?                                      | 1.7                                     |
-| Python versions supported                                           | 3.6-3.9                                     | 2.6-3.6                                   | 2.6-3.6                                 |
+| Python versions supported                                           | 3.6-3.10                                    | 2.6-3.6                                   | 2.6-3.6                                 |
 | Save and load password protected (encrypted) PDFs                   | ✔ (except public key)                       | ✘ (Only obsolete RC4)                     | ✘ (not at all)                          |
 | Save and load PDF compressed object streams (PDF 1.5)               | ✔                                           | ✘                                         | ✘                                       |
 | Creates linearized ("fast web view") PDFs                           | ✔                                           | ✘                                         | ✘                                       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ exclude = '''
 [tool.cibuildwheel]
 test-command = "pytest -nauto {project}/tests"
 test-extras = "test"
-skip = "cp310-*"
 test-skip = "*_arm64 *_universal2:arm64"
 
 [tool.cibuildwheel.environment]
@@ -65,7 +64,7 @@ before-all = "brew install qpdf"
 # pp3*-win_amd64 does not execute because cibuildwheel does not implement it
 # or PyPy3 doesn't work on Windows 64-bit, one or the other
 # PyPy+Win32 seems like a very low priority combination
-skip = "pp3* cp310-*"
+skip = "pp3*"
 
 [tool.mypy]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics


### PR DESCRIPTION
From the 3.10 release notes:

> There will be no ABI changes from this point forward in the 3.10 series and the goal is that there will be as few code changes as possible.

So it is, roughly-speaking, safe to start building 3.10 wheels, but it seems we need to wait for pillow: python-pillow/Pillow#5569

I managed to fix a bug in the CI setup, but there's still something missing to get Pillow to load correctly in all tests.