### PR TITLE
Follow the spdx standard for copyright headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca> -->
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 pikepdf
 =======
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 pikepdf Documentation
 =====================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Installation
 ============
 

--- a/docs/references/arch.rst
+++ b/docs/references/arch.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Architecture
 ============
 

--- a/docs/references/contributing.rst
+++ b/docs/references/contributing.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 =======================
 Contributing guidelines
 =======================

--- a/docs/references/debugging.rst
+++ b/docs/references/debugging.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Debugging
 =========
 

--- a/docs/references/resources.rst
+++ b/docs/references/resources.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Resources
 =========
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _changelog:
 
 Release notes

--- a/docs/topics/attachments.rst
+++ b/docs/topics/attachments.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _attachments:
 
 Attaching files to a PDF

--- a/docs/topics/content_streams.rst
+++ b/docs/topics/content_streams.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _working_with_content_streams:
 
 Working with content streams

--- a/docs/topics/encoding.rst
+++ b/docs/topics/encoding.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Character encoding
 ******************
 

--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Working with images
 ===================
 

--- a/docs/topics/metadata.rst
+++ b/docs/topics/metadata.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _metadata:
 
 PDF Metadata

--- a/docs/topics/nametrees.rst
+++ b/docs/topics/nametrees.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Name trees
 **********
 

--- a/docs/topics/objects.rst
+++ b/docs/topics/objects.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Object model
 ************
 

--- a/docs/topics/outlines.rst
+++ b/docs/topics/outlines.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _outlines:
 
 Outlines

--- a/docs/topics/overlays.rst
+++ b/docs/topics/overlays.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _overlays:
 
 Overlays, underlays, watermarks, n-up

--- a/docs/topics/page.rst
+++ b/docs/topics/page.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _work_with_pages:
 
 Working with pages

--- a/docs/topics/pages.rst
+++ b/docs/topics/pages.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _docassembly:
 
 PDF split, merge, and document assembly

--- a/docs/topics/security.rst
+++ b/docs/topics/security.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _security:
 
 PDF security

--- a/docs/topics/streams.rst
+++ b/docs/topics/streams.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 Stream objects
 ==============
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,3 +1,6 @@
+.. SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
 .. _tutorial:
 
 Tutorial

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 [metadata]
 name = pikepdf
 description = Read and write PDFs with Python, powered by qpdf

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import sys
 from glob import glob
 from os import environ

--- a/src/pikepdf/__init__.py
+++ b/src/pikepdf/__init__.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 """A library for manipulating PDFs
 

--- a/src/pikepdf/_cpphelpers.py
+++ b/src/pikepdf/_cpphelpers.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 """
 Support functions called by the C++ library binding layer. Not intended to be

--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 """
 In several cases the implementation of some higher levels features might as

--- a/src/pikepdf/_version.py
+++ b/src/pikepdf/_version.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution as _get_distribution

--- a/src/pikepdf/_xml.py
+++ b/src/pikepdf/_xml.py
@@ -1,9 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2021, James R. Barlow (https://github.com/jbarlow83/)
-
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 from typing import IO, Any, AnyStr, Union
 

--- a/src/pikepdf/codec.py
+++ b/src/pikepdf/codec.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 import codecs
 from typing import Container, Optional, Tuple

--- a/src/pikepdf/jbig2.py
+++ b/src/pikepdf/jbig2.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 import os
 from distutils.version import LooseVersion

--- a/src/pikepdf/models/__init__.py
+++ b/src/pikepdf/models/__init__.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 from typing import Collection, List, Tuple, Union, cast
 

--- a/src/pikepdf/models/encryption.py
+++ b/src/pikepdf/models/encryption.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 from typing import Any, Dict, NamedTuple
 

--- a/src/pikepdf/models/image.py
+++ b/src/pikepdf/models/image.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 import base64
 import struct

--- a/src/pikepdf/models/matrix.py
+++ b/src/pikepdf/models/matrix.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 from math import cos, pi, sin
 

--- a/src/pikepdf/models/metadata.py
+++ b/src/pikepdf/models/metadata.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2018, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 import logging
 import re

--- a/src/pikepdf/models/outlines.py
+++ b/src/pikepdf/models/outlines.py
@@ -1,10 +1,6 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2020, Matthias Erll
-# Copyright (C) 2020, James R. Barlow (https://github.com/jbarlow83/)
-
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-FileCopyrightText: 2020 Matthias Erll
+# SPDX-License-Identifier: MPL-2.0
 
 from enum import Enum
 from itertools import chain

--- a/src/pikepdf/objects.py
+++ b/src/pikepdf/objects.py
@@ -1,8 +1,5 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
 """Provide classes to stand in for PDF objects
 

--- a/src/qpdf/annotation.cpp
+++ b/src/qpdf/annotation.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2019, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <qpdf/Constants.h>
 #include <qpdf/Types.h>

--- a/src/qpdf/embeddedfiles.cpp
+++ b/src/qpdf/embeddedfiles.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2019, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <qpdf/Constants.h>
 #include <qpdf/Types.h>

--- a/src/qpdf/gsl.h
+++ b/src/qpdf/gsl.h
@@ -1,18 +1,5 @@
-///////////////////////////////////////////////////////////////////////////////
-//
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
-//
-// This code is licensed under the MIT License (MIT).
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-///////////////////////////////////////////////////////////////////////////////
+// SPDX-FileCopyrightText: 2015 Microsoft Corporation
+// SPDX-License-Identifier: MIT
 
 // Simplified from
 // https://raw.githubusercontent.com/microsoft/GSL/master/include/gsl/gsl_util

--- a/src/qpdf/mmap_inputsource-inl.h
+++ b/src/qpdf/mmap_inputsource-inl.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstdio>
 #include <cstring>

--- a/src/qpdf/nametree.cpp
+++ b/src/qpdf/nametree.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2019, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <qpdf/Constants.h>
 #include <qpdf/Types.h>

--- a/src/qpdf/object.cpp
+++ b/src/qpdf/object.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cctype>
 

--- a/src/qpdf/object_convert.cpp
+++ b/src/qpdf/object_convert.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 /*
  * Convert Python types <-> QPDFObjectHandle types

--- a/src/qpdf/object_repr.cpp
+++ b/src/qpdf/object_repr.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 /*
  * Implement repr() for QPDFObjectHandle

--- a/src/qpdf/page.cpp
+++ b/src/qpdf/page.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <sstream>
 #include <iostream>

--- a/src/qpdf/parsers.cpp
+++ b/src/qpdf/parsers.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2021, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <sstream>
 #include <locale>

--- a/src/qpdf/pikepdf.cpp
+++ b/src/qpdf/pikepdf.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2019, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <sstream>
 #include <type_traits>

--- a/src/qpdf/pikepdf.h
+++ b/src/qpdf/pikepdf.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #pragma once
 

--- a/src/qpdf/pipeline.cpp
+++ b/src/qpdf/pipeline.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <qpdf/Constants.h>
 #include <qpdf/Types.h>

--- a/src/qpdf/pipeline.h
+++ b/src/qpdf/pipeline.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #pragma once
 

--- a/src/qpdf/qpdf.cpp
+++ b/src/qpdf/qpdf.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <sstream>
 #include <type_traits>

--- a/src/qpdf/qpdf_inputsource-inl.h
+++ b/src/qpdf/qpdf_inputsource-inl.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstdio>
 #include <cstring>

--- a/src/qpdf/qpdf_pagelist.cpp
+++ b/src/qpdf/qpdf_pagelist.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include "pikepdf.h"
 #include "qpdf_pagelist.h"

--- a/src/qpdf/qpdf_pagelist.h
+++ b/src/qpdf/qpdf_pagelist.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #pragma once
 

--- a/src/qpdf/rectangle.cpp
+++ b/src/qpdf/rectangle.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2019, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <qpdf/QPDFObjectHandle.hh>
 

--- a/src/qpdf/tokenfilter.cpp
+++ b/src/qpdf/tokenfilter.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2021, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <sstream>
 #include <iostream>

--- a/src/qpdf/utils.cpp
+++ b/src/qpdf/utils.cpp
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #include <cstdlib>
 #include <system_error>

--- a/src/qpdf/utils.h
+++ b/src/qpdf/utils.h
@@ -1,10 +1,5 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * Copyright (C) 2017, James R. Barlow (https://github.com/jbarlow83/)
- */
+// SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+// SPDX-License-Identifier: MPL-2.0
 
 #pragma once
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import os
 import platform

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import os
 import platform
 import sys

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 from conftest import needs_libqpdf_v

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 from conftest import needs_libqpdf_v
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import datetime
 from hashlib import md5
 from pathlib import Path

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import datetime
 from hashlib import md5

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import os
 from io import BytesIO

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import os
 from io import BytesIO
 from pathlib import Path

--- a/tests/test_decimal.py
+++ b/tests/test_decimal.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 from decimal import Decimal, getcontext
 

--- a/tests/test_decimal.py
+++ b/tests/test_decimal.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 from decimal import Decimal, getcontext
 
 import pytest

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,5 +1,7 @@
-import pytest
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
+import pytest
 from pikepdf import Pdf
 
 # pylint: disable=redefined-outer-name,pointless-statement,expression-not-assigned

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 from pikepdf import Pdf

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,5 +1,7 @@
-import pytest
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
+import pytest
 import pikepdf
 
 # pylint: disable=redefined-outer-name

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 import pikepdf

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 
 import pikepdf

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 
 from pikepdf import Page, Pdf, PdfError, Token, TokenFilter, TokenType

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -1,5 +1,7 @@
-import pytest
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
+import pytest
 from pikepdf import Dictionary, ForeignObjectError, Name, Object, Pdf, Stream
 
 

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 from pikepdf import Dictionary, ForeignObjectError, Name, Object, Pdf, Stream

--- a/tests/test_formxobject.py
+++ b/tests/test_formxobject.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 
 from pikepdf import Dictionary, Name, Object, Pdf, Stream

--- a/tests/test_formxobject.py
+++ b/tests/test_formxobject.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 

--- a/tests/test_image_access.py
+++ b/tests/test_image_access.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import subprocess
 import zlib

--- a/tests/test_image_access.py
+++ b/tests/test_image_access.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import subprocess
 import zlib
 from contextlib import contextmanager

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import os.path
 import sys
 from io import BytesIO, FileIO

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import os.path
 import sys

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 """
 Test IPython/Jupyter display hooks
 """

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 """
 Test IPython/Jupyter display hooks

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 from math import isclose
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 from math import isclose
 
 import pytest

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import os
 import re
 from datetime import datetime, timedelta, timezone, tzinfo

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import os
 import re

--- a/tests/test_nametree.py
+++ b/tests/test_nametree.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 

--- a/tests/test_nametree.py
+++ b/tests/test_nametree.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 
 from pikepdf import Array, Dictionary, NameTree, Object, Pdf

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import json
 import sys
 from copy import copy

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import json
 import sys

--- a/tests/test_objectlist.py
+++ b/tests/test_objectlist.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import pytest
 import pikepdf

--- a/tests/test_objectlist.py
+++ b/tests/test_objectlist.py
@@ -1,5 +1,7 @@
-import pytest
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
 
+import pytest
 import pikepdf
 
 

--- a/tests/test_outlines.py
+++ b/tests/test_outlines.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 from datetime import timedelta
 from itertools import repeat

--- a/tests/test_outlines.py
+++ b/tests/test_outlines.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 from datetime import timedelta
 from itertools import repeat
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 from typing import Type
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 from typing import Type
 
 import pytest

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import gc
 from contextlib import suppress
 from shutil import copy

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import gc
 from contextlib import suppress

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import shutil
 import sys
 from subprocess import PIPE, run

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import shutil
 import sys

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 """
 Testing focused on pikepdf.Pdf
 """

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 """
 Testing focused on pikepdf.Pdf

--- a/tests/test_pdfa.py
+++ b/tests/test_pdfa.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import os
 import xml.etree.ElementTree as ET

--- a/tests/test_pdfa.py
+++ b/tests/test_pdfa.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path

--- a/tests/test_private_pdfs.py
+++ b/tests/test_private_pdfs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import gzip
 from pathlib import Path
 

--- a/tests/test_private_pdfs.py
+++ b/tests/test_private_pdfs.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import gzip
 from pathlib import Path

--- a/tests/test_rectangle.py
+++ b/tests/test_rectangle.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 from decimal import Decimal
 
 import pytest

--- a/tests/test_rectangle.py
+++ b/tests/test_rectangle.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 from decimal import Decimal
 

--- a/tests/test_refcount.py
+++ b/tests/test_refcount.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 import gc
 
 try:

--- a/tests/test_refcount.py
+++ b/tests/test_refcount.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 import gc
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
+# SPDX-License-Identifier: MPL-2.0
+
 """
 A bunch of quick tests that confirm nothing is horribly wrong
 """

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2021 James R. Barlow <james@purplerock.ca>
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC0-1.0
 
 """
 A bunch of quick tests that confirm nothing is horribly wrong


### PR DESCRIPTION
Modified all headers to follow the [spdx standard](https://spdx.dev/).

Also added copyright/license information to test code and documentation:
- used CC0-1.0 for test code (as indicated in [`debian/copyright`](https://github.com/pikepdf/pikepdf/blob/master/debian/copyright))
- assumed CC-BY-SA-4.0 for documentation (like OCRmyPDF)

(If you have different preferences this could be changed, of course.)

Moreover, there is the [reuse standard](https://reuse.software/) and its corresponding command-line tool, but making pikepdf truly reuse compliant would require some more changes.
