### PR TITLE
Make attachments.rst build reproducible

### DIFF
--- a/docs/topics/attachments.rst
+++ b/docs/topics/attachments.rst
@@ -30,7 +30,7 @@ Now we can retrive the data.
 
     In [1]: pdf.attachments['README.md']
 
-    In [1]: pdf.attachments['README.md'].get_file()
+    In [1]: file = pdf.attachments['README.md'].get_file()
 
     In [1]: pdf.attachments['README.md'].get_file().read_bytes()[:50]
 


### PR DESCRIPTION
The documentation has an embedded example that shows the repr(..) of an object
which, as it happens, includes the current build date, rendering the package
unreproducible.  This change should not affect the usefulness of the example.