### PR TITLE
Fix _over_underlay's default rect handling

### DIFF
--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -1155,7 +1155,7 @@ class Extend_Page:
             other: A Page or Form XObject to render as an underlay underneath this
                 page.
             rect: The PDF rectangle (in PDF units) in which to draw the underlay.
-                If omitted, this page's MediaBox will be used.
+                If omitted, this page's trimbox, cropbox or mediabox will be used.
 
         .. versionadded:: 2.14
         """

--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -1086,11 +1086,9 @@ class Extend_Page:
     ) -> None:
         formx = None
         if isinstance(other, Page):
-            page = other
             formx = other.as_form_xobject()
         elif isinstance(other, Dictionary) and other.get(Name.Type) == Name.Page:
-            page = Page(other)
-            formx = page.as_form_xobject()
+            formx = Page(other).as_form_xobject()
         elif (
             isinstance(other, Stream)
             and other.get(Name.Type) == Name.XObject
@@ -1102,7 +1100,7 @@ class Extend_Page:
             raise TypeError("other object is not something we can convert to FormX")
 
         if rect is None:
-            rect = Rectangle(page.trimbox)
+            rect = Rectangle(self.trimbox)
 
         formx_placed_name = self.add_resource(formx, Name.XObject)
         cs = self.calc_form_xobject_placement(formx, formx_placed_name, rect)


### PR DESCRIPTION
The docs for [add_overlay](https://pikepdf.readthedocs.io/en/latest/api/models.html#pikepdf.Page.add_overlay) and [add_underlay](https://pikepdf.readthedocs.io/en/latest/api/models.html#pikepdf.Page.add_underlay) indicate that if the `rect` parameter is "omitted, this page’s trimbox, cropbox or mediabox will be used".

When trying to add a Form XObject overlay to a page without setting the `rect` parameter, I ran into an exception at [_methods.py#L1105](https://github.com/pikepdf/pikepdf/blob/d641327a5b056ad2b7b5e642ed321272a0af9d15/src/pikepdf/_methods.py#L1105): `UnboundLocalError: local variable 'page' referenced before assignment`. This method was added in https://github.com/pikepdf/pikepdf/commit/ddc86c02f640f0417943a5c2b4ec35729c9366c6 and modified slightly in https://github.com/pikepdf/pikepdf/commit/cb08158d57f6932a78e2734a7202123f55cb4c32, when a similar `UnboundLocalError` exception was encountered. I think the fix in the second linked commit was incorrect: rather than setting the "missing" `page` variable, to align with the behaviour described in the docs, `rect = Rectangle(page.trimbox)` should have been changed to `rect = Rectangle(self.trimbox)`.