### PR TITLE
Correct class name in PdfMatrix __repr__

### DIFF
--- a/src/pikepdf/models/matrix.py
+++ b/src/pikepdf/models/matrix.py
@@ -130,4 +130,4 @@ class PdfMatrix:
         ).encode()
 
     def __repr__(self):
-        return 'pikepdf.Matrix(' + repr(self.values) + ')'
+        return f"pikepdf.PdfMatrix({repr(self.values)})"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -12,7 +12,7 @@ def test_init_6():
     m2t = m2.translated(2, 3)
     assert (
         repr(m2t)
-        == 'pikepdf.Matrix(((2.0, 0.0, 0.0), (0.0, 2.0, 0.0), (2.0, 3.0, 1.0)))'
+        == 'pikepdf.PdfMatrix(((2.0, 0.0, 0.0), (0.0, 2.0, 0.0), (2.0, 3.0, 1.0)))'
     )
     m2tr = m2t.rotated(90)
     assert isclose(m2tr.a, 0, abs_tol=1e-6)


### PR DESCRIPTION
Quick typo fix-- I noticed that __repr__ for the PdfMatrix class uses the wrong class name (I thought maybe I'd missed something and there were two separate matrix representations).

I changed it to use a format string for consistency with other classes' __repr__ implementations.