### PR TITLE
Moving py::gil_scoped_release after make_unique InputSource calls.

### DIFF
--- a/src/qpdf/qpdf.cpp
+++ b/src/qpdf/qpdf.cpp
@@ -99,9 +99,9 @@ std::shared_ptr<QPDF> open_pdf(py::object filename_or_stream,
 
     if (access_mode == access_mmap || access_mode == access_mmap_only) {
         try {
-            py::gil_scoped_release release;
             auto mmap_input_source =
                 std::make_unique<MmapInputSource>(stream, description, closing_stream);
+            py::gil_scoped_release release;
             auto input_source = PointerHolder<InputSource>(mmap_input_source.release());
             q->processInputSource(input_source, password.c_str());
             success = true;
@@ -117,9 +117,9 @@ std::shared_ptr<QPDF> open_pdf(py::object filename_or_stream,
     }
 
     if (!success && access_mode == access_stream) {
-        py::gil_scoped_release release;
         auto stream_input_source = std::make_unique<PythonStreamInputSource>(
             stream, description, closing_stream);
+        py::gil_scoped_release release;
         auto input_source = PointerHolder<InputSource>(stream_input_source.release());
         q->processInputSource(input_source, password.c_str());
         success = true;


### PR DESCRIPTION
Fixing GIL-not-held issues.

The Python GIL is not held when `Py_INCREF` is invoked (via pybind11) in these two lines:

* https://github.com/rwgk/pikepdf/blob/63b660b68b52a0f99ced3015fe4acb66fb6ca8d5/src/qpdf/mmap_inputsource-inl.h#L45 when called from https://github.com/rwgk/pikepdf/blob/63b660b68b52a0f99ced3015fe4acb66fb6ca8d5/src/qpdf/qpdf.cpp#L103
* https://github.com/rwgk/pikepdf/blob/63b660b68b52a0f99ced3015fe4acb66fb6ca8d5/src/qpdf/qpdf_inputsource-inl.h#L31 when called from https://github.com/rwgk/pikepdf/blob/63b660b68b52a0f99ced3015fe4acb66fb6ca8d5/src/qpdf/qpdf.cpp#L121

-------------------------------------

How was this discovered?

I'm working on a systematic cleanup of the extended Google codebase, which imports this github project.

I'm globally testing with this Python patch (Python 3.7):

```
+int PyGILState_Check(void); /* Include/internal/pystate.h */
+
 #define Py_INCREF(op) (                         \
+    assert(PyGILState_Check()),                 \
     _Py_INC_REFTOTAL  _Py_REF_DEBUG_COMMA       \
     ((PyObject *)(op))->ob_refcnt++)

 #define Py_DECREF(op)                                   \
     do {                                                \
+        assert(PyGILState_Check());                     \
         PyObject *_py_decref_tmp = (PyObject *)(op);    \
         if (_Py_DEC_REFTOTAL  _Py_REF_DEBUG_COMMA       \
         --(_py_decref_tmp)->ob_refcnt != 0)             \
```

The pikepdf tests fail, but are fixed with the change under this PR.

General background: The GIL must be held when calling any Python C API functions. In multithreaded applications that use callbacks this requirement can easily be violated by accident. A general tool to ensure GIL health is not available, but patching Python Py_INCREF & Py_DECREF as above provides a basic health check.

More background for easy reference: https://docs.python.org/3/glossary.html#term-global-interpreter-lock

Purely FYI: this was another issue uncovered with the patch above: https://reviews.llvm.org/D114722