### PR TITLE
Switch to tomli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,9 +105,9 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install toml and read environment from pyproject.toml
+      - name: Install tomli and read environment from pyproject.toml
         run: |
-          python -m pip install toml
+          python -m pip install tomli
           python build-scripts/environ-from-pyproject.py >> $env:GITHUB_ENV
           dir env:
 
@@ -141,9 +141,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jbig2dec lcov
 
-      - name: Install toml and read environment from pyproject.toml
+      - name: Install tomli and read environment from pyproject.toml
         run: |
-          python -m pip install toml
+          python -m pip install tomli
           python build-scripts/environ-from-pyproject.py >> $GITHUB_ENV
 
       - name: Download QPDF

--- a/build-scripts/environ-from-pyproject.py
+++ b/build-scripts/environ-from-pyproject.py
@@ -1,5 +1,6 @@
-import toml
+import tomli
 
-t = toml.load('pyproject.toml')
+with open('pyproject.toml', 'rb') as f:
+	t = tomli.load(f)
 env = t['tool']['cibuildwheel']['environment']
 print('\n'.join(f'{k}={v}' for k, v in env.items()))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-import toml
+import tomli
 from pkg_resources import get_distribution
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
@@ -106,7 +106,8 @@ autosummary_generate = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-pyproject_toml = toml.load('../pyproject.toml')
+with open('../pyproject.toml', 'rb') as f:
+    pyproject_toml = toml.load(f)
 toml_env = pyproject_toml['tool']['cibuildwheel']['environment']
 
 rst_prolog = f"""

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,7 @@ Sphinx >= 3
 sphinx-issues
 sphinx-panels
 sphinx-rtd-theme
-toml
+tomli
 
 GitPython
 PyGithub

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,13 +63,12 @@ docs =
     sphinx-issues
     sphinx-panels
     sphinx-rtd-theme
-    toml
+    tomli
 mypy =
     lxml-stubs
     types-Pillow
     types-requests
     types-setuptools
-    types-toml
 test =
     Pillow>=7,<10
     attrs>=20.2.0
@@ -82,7 +81,7 @@ test =
     pytest-timeout>=1.4.2
     pytest-xdist>=1.28,<3
     python-dateutil>=2.8.0
-    toml
+    tomli
     python-xmp-toolkit>=2.0.1 ;sys_platform != "nt" and platform_machine == "x86_64"
 
 [options.package_data]

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from shutil import copy
 
 import pytest
-import toml
+import tomli
 from packaging.version import Version
 
 import pikepdf
@@ -19,7 +19,8 @@ from pikepdf import Name, Object, Pdf, Stream
 def test_minimum_qpdf_version():
     from pikepdf import _qpdf
 
-    pyproject_toml = toml.load(Path(__file__).parent / '../pyproject.toml')
+    with open(Path(__file__).parent / '../pyproject.toml', 'rb') as f:
+        pyproject_toml = tomli.load(f)
     toml_env = pyproject_toml['tool']['cibuildwheel']['environment']
 
     assert Version(_qpdf.qpdf_version()) >= Version(toml_env['QPDF_MIN_VERSION'])


### PR DESCRIPTION
The original "toml" package is no longer maintained and is not compliant
with TOML 1.0.0.  Use "tomli" instead, following other projects.
"tomli" will most likely also serve as the base for stdlib TOML support.