### PR TITLE
Remove no-longer-needed linker flags with qpdf_source_tree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,6 @@ if sys.platform == 'cygwin':
 # module[0].extra_compile_args.append('-g3')
 
 if qpdf_source_tree:
-    dtags = '' if sys.platform in ('darwin', 'bsd') else ',--enable-new-dtags' 
-    extmodule.extra_link_args.append(dtags)
     for lib in extra_library_dirs:
         extmodule.extra_link_args.append(  # type: ignore    
             f'-Wl,-rpath,{lib}'


### PR DESCRIPTION
My instructions for building and testing pikepdf from a qpdf source tree included using `pip3 install -r requires/test.txt` to install test dependencies.

I see from 8138794ed03ff0adda87c42300130088d7b47ad9 that this is no longer applicable. Although I'm not up to date on Python packaging changes, look at your github workflows and commit history made me try `pip install '.[test]'`. I think this should be right, but let me know if not.

In any case, when I did that, I got this output:
```
× Building wheel for pikepdf (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      running bdist_wheel
      running build
      running build_py
      running egg_info
      writing src/pikepdf.egg-info/PKG-INFO
      writing dependency_links to src/pikepdf.egg-info/dependency_links.txt
      writing requirements to src/pikepdf.egg-info/requires.txt
      writing top-level names to src/pikepdf.egg-info/top_level.txt
      adding license file 'LICENSE.txt'
      adding license file 'licenses/license.wheel.txt'
      running build_ext
      building 'pikepdf._qpdf' extension
      /bin/ld: cannot find ,--enable-new-dtags: No such file or directory
      collect2: error: ld returned 1 exit status
      error: command '/bin/x86_64-linux-gnu-g++' failed with exit code 1
      [end of output]
```

on my Ubuntu 21.10 system. This patch removes `--enable-new-dtags`, which seems to resolve the problem. I get a test failure which I will report in a separate issue.