### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        platform: [manylinux_x86_64, manylinux_i686] # yet not doing musllinux_x86_64, i686 (dependency issues), manylinux_aarch64 (too expensive)
+        platform: [manylinux_x86_64, manylinux_i686, manylinux_aarch64] # yet not doing musllinux_x86_64, i686 (dependency issues)
 
     steps:
       - uses: actions/checkout@v2
@@ -38,6 +38,7 @@ jobs:
         if: matrix.platform == 'manylinux_aarch64'
         env:
           CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: pp*
 
       - name: Upload built wheels
         uses: actions/upload-artifact@v2

--- a/build-scripts/linux-build-wheel-deps.bash
+++ b/build-scripts/linux-build-wheel-deps.bash
@@ -15,7 +15,11 @@ fi
 
 if [ ! -f /usr/local/lib/libqpdf.a ]; then
     pushd qpdf
-    ./configure --disable-oss-fuzz && make -j install
+    if [[ $(uname -p) == 'aarch64' ]]; then
+        ./configure --disable-oss-fuzz && make install
+    else
+        ./configure --disable-oss-fuzz && make -j install
+    fi
     find /usr/local/lib -name 'libqpdf.so*' -type f -exec strip --strip-debug {} \+
     popd
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ before-all = [
   "apk add py3-lxml py3-pillow python3 py3-setuptools py3-pybind11-dev python3-dev py3-wheel qpdf-dev exempi-dev"
 ]
 
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_aarch64"
+test-command = "pytest -nauto {project}/tests/test_sanity.py"
+
 [tool.cibuildwheel.macos]
 before-all = "brew install qpdf little-cms2"
 


### PR DESCRIPTION
Added linux aarch64 wheel build support.
Related to https://github.com/pikepdf/pikepdf/issues/194, @jbarlow83 Could you please review this PR?