### PR TITLE
compatibly support build with qpdf current main (cmake, PointerHolder)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -243,14 +243,18 @@ recent version of QPDF than your operating system package manager provides, and 
 do not want to use Python wheels.
 
 * Set the environment variable ``QPDF_SOURCE_TREE`` to the location of the QPDF source
-  tree.
+  tree. Set the environment variable ``QPDF_BUILD_LIBDIR`` to the directory that
+  contains the shared library built by cmake from this source tree. Typically this
+  will be ``.../build/libqpdf`` where ``.../build`` represents the cmake build
+  directory. If you are using a multi-configuration generator, it may be in a
+  subdirectory of that.
 
-* Build QPDF, by running ``make``. Refer to the QPDF installation instructions for
+* Build QPDF, by running ``cmake``. Refer to the QPDF installation instructions for
   further options and details.
 
 * On Linux, modify ``LD_LIBRARY_PATH``, prepending the path where the QPDF build
-  produces ``libqpdfXX.so``. This might be something like
-  ``$QPDF_SOURCE_TREE/.build/libs/libqpdfXX.so``. On macOS, locate the equivalent
+  produces ``libqpdfXX.so``. This is the same directory you assigned the
+  ``QPDF_BUILD_LIBRARY`` environment variable to. On macOS, the equivalent
   variable is ``DYLD_LIBRARY_PATH``. On Windows, no action is needed. Generally,
   what you are doing here is telling the runtime dynamic linker to use the custom
   compiled version of QPDF instead of the system version.

--- a/docs/references/debugging.rst
+++ b/docs/references/debugging.rst
@@ -36,8 +36,8 @@ Download QPDF and compile a debug build:
 
     # in QPDF source tree
     cd $QPDF_SOURCE_TREE
-    ./configure CFLAGS='-g -O0' CPPFLAGS='-g -O0' CXXFLAGS='-g -O0'
-    make -j
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+    cmake --build build -j
 
 Compile and link against QPDF source tree
 -----------------------------------------
@@ -47,20 +47,25 @@ system version:
 
 .. code-block:: bash
 
-    env QPDF_SOURCE_TREE=<location of QPDF> python setup.py build_ext --inplace
+    env QPDF_SOURCE_TREE=<location of QPDF> \
+      QPDF_BUILD_LIBDIR=<directory containing libqpdf.so> \
+      python setup.py build_ext --inplace
 
-In addition to building against the QPDF source, you'll need to force your operating
-system to load the locally compiled version of QPDF instead of the installed version:
+The libqpdf.so file should be located in the ``libqpdf`` subdirectory of your cmake
+build directory but may be in a subdirectory of that if you are using a
+multi-configuration generator with cmake. In addition to building against the QPDF
+source, you'll need to force your operating system to load the locally compiled
+version of QPDF instead of the installed version:
 
 .. code-block:: bash
 
     # Linux
-    env LD_LIBRARY_PATH=$QPDF_SOURCE_TREE/libqpdf/build/.libs python ...
+    env LD_LIBRARY_PATH=<directory containing libqpdf.so> python ...
 
 .. code-block:: bash
 
     # macOS - may require disabling System Integrity Protection
-    env DYLD_LIBRARY_PATH=$QPDF_SOURCE_TREE/libqpdf/build/.libs python ...
+    env DYLD_LIBRARY_PATH=<directory containing libqpdf.so> python ...
 
 On macOS you can make the library persistent by changing the name of the library
 to use in pikepdf's binary extension module:
@@ -68,7 +73,7 @@ to use in pikepdf's binary extension module:
 .. code-block:: bash
 
     install_name_tool -change /usr/local/lib/libqpdf*.dylib \
-        $QPDF_SOURCE_TREE/libqpdf/build/.libs/libqpdf*.dylib \
+        $QPDF_BUILD_LIBDIR/libqpdf*.dylib \
         src/pikepdf/_qpdf.cpython*.so
 
 You can also run Python through a debugger (``gdb`` or ``lldb``) in this manner,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from setuptools import Extension, setup
 extra_includes = []
 extra_library_dirs = []
 qpdf_source_tree = environ.get('QPDF_SOURCE_TREE', '')
+qpdf_build_libdir = environ.get('QPDF_BUILD_LIBDIR', '')
 
 # If CFLAGS is defined, disable any efforts to shim the build, because
 # the caller is probably a maintainer and knows what they are doing.
@@ -26,7 +27,17 @@ if not cflags_defined:
     if qpdf_source_tree:
         # Point this to qpdf source tree built with shared libaries
         extra_includes.append(join(qpdf_source_tree, 'include'))
-        extra_library_dirs.append(join(qpdf_source_tree, 'libqpdf/build/.libs'))
+        if not qpdf_build_libdir:
+            # Pre-cmake qpdf build
+            old_libdir = join(qpdf_source_tree, 'libqpdf/build/.libs')
+            if exists(old_libdir):
+                qpdf_build_libdir = old_libdir
+        if not qpdf_build_libdir:
+            raise Exception(
+                'Please set QPDF_BUILD_LIBDIR to the directory'
+                ' containing your libqpdf.so built from'
+                ' $QPDF_SOURCE_TREE')
+        extra_library_dirs.append(join(qpdf_build_libdir))
 
     if 'bsd' in sys.platform:
         extra_includes.append('/usr/local/include')


### PR DESCRIPTION
qpdf's build is switching from autoconf and libdir to cmake. These changes switch the QPDF_SOURCE_TREE bit of pikepdf so that you can test against a qpdf source tree after the cmake transition is complete. I have tested these changes with my cmake branch.

The changes to setup.py are made such that they are backward compatible with a pre-cmake build. The documentation changes are not. (By the way, there was a typo in the old docs -- they mentioned `.build/libs` in one place instead of `build/.libs`.

~~Please #316 for a separate PR that includes only the setup.py change in case you wanted to merge that earlier. I haven't looked in pikepdf for other references to any qpdf build, but the change to setup.py is sufficient to allow me to continue to test pikepdf against qpdf as I move forward post-cmake.~~

The setup.py change could be accepted at any time. The documentation change may be premature to accept since it won't be accurate until a version of qpdf that uses cmake is released. I am still deciding whether to release qpdf 10.6.x with cmake (the cmake build is fully binary compatible with the autoconf build) or whether to wait.

I will be making some kind of announcement to qpdf-announce about testing the cmake build soon.