### PR TITLE
Add list of attachment icons and update example

### DIFF
--- a/docs/topics/attachments.rst
+++ b/docs/topics/attachments.rst
@@ -83,7 +83,8 @@ Creating attachment annotations
 You can also create PDF Annotations and Actions that contain attached files.
 
 Here is an example of an annotation that displays an icon. Clicking the icon
-prompt the user to view the attached document.
+prompt the user to view the attached document. Valid icons and their relative size are: 
+`Graph` (40 x 40),  `PushPin` (28 x 40), `Paperclip` (14 x 34) and `Tag` (40 x 32).
 
 .. ipython::
 
@@ -91,12 +92,18 @@ prompt the user to view the attached document.
 
   In [1]: filespec = AttachedFileSpec.from_filepath(pdf, Path('../README.md'))
 
+  In [1]: icon_size = (28, 40)
+  
+  In [1]: icon_location = (144, 648, 144 + icon_size[0] * 2, 648 + icon_size[1] * 2)
+  
+  In [1]: locationfilespec = AttachedFileSpec.from_filepath(pdf, Path('../README.md'))
+
   In [1]: pushpin = Dictionary(
      ...:     Type=Name.Annot,
      ...:     Subtype=Name.FileAttachment,
-     ...:     Name=Name.GraphPushPin,
+     ...:     Name=Name.PushPin,
      ...:     FS=filespec.obj,
-     ...:     Rect=[2*72, 9*72, 3*72, 10*72],
+     ...:     Rect=icon_location,
      ...: )
 
   In [1]: pdf.pages[0].Annots = pdf.make_indirect(Array([


### PR DESCRIPTION
Hello, just a simple PR in the docs with the list of icons (and their aspect ratio) for attachments. I got the info [here](https://www.pdftron.com/api/PDFTronSDK/dotnet/pdftron.PDF.Annots.FileAttachment.html#pdftron_PDF_Annots_FileAttachment_Create_pdftron_SDF_SDFDoc_pdftron_PDF_Rect_System_String_).