### PR TITLE
Fix test_page_attrs for Python 3.11.

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -259,7 +259,7 @@ def test_page_attrs(graph):
     assert isinstance(graph.pages[0].Resources, Dictionary)
 
     del graph.pages[0].Resources
-    with pytest.raises(AttributeError, match="can't delete"):
+    with pytest.raises(AttributeError, match=r"can't delete|property of 'Page' object has no deleter"):
         del graph.pages[0].obj
     del graph.pages[0]['/Contents']
 


### PR DESCRIPTION
The error message is different in Python 3.11.
See: https://github.com/python/cpython/commit/0cb765b2cec9b020224af016a83bf35c45b71932