### PR TITLE
Fix importlib_metadata.version not working properly with PyInstaller。…

### DIFF
--- a/src/pikepdf/_version.py
+++ b/src/pikepdf/_version.py
@@ -10,6 +10,9 @@ try:
 except ImportError:
     from importlib.metadata import version as _package_version
 
-__version__ = _package_version('pikepdf')
+try:
+    __version__ = _package_version('pikepdf')
+except Exception:
+    __version__ = "Not installed"
 
 __all__ = ['__version__']


### PR DESCRIPTION
Fix importlib_metadata.version not working properly with PyInstaller。Cause an abnormal exit。