### PR TITLE
docs: fix broken link for PDF specification in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ to encrypted PDFs.
 
 It is a low level library that requires knowledge of PDF internals and some
 familiarity with the `PDF specification
-<https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf>`_.
+<https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf>`_.
 It does not provide a user interface of its own.
 
 pikepdf would help you build apps that do things like:


### PR DESCRIPTION
I was reading the documentation and realized that the PDF Spec link was throwing a 404 - this small pull request should fix that.