### PR TITLE
docs: typo fixes

### DIFF
--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -15,7 +15,7 @@ Main objects
 .. class:: pikepdf.ObjectStreamMode
 
     Options for saving streams within PDFs, which are more a compact
-    way of saving certains types of data that was added in PDF 1.5. All
+    way of saving certain types of data that was added in PDF 1.5. All
     modern PDF viewers support object streams, but some third party tools
     and libraries cannot read them.
 

--- a/docs/topics/attachments.rst
+++ b/docs/topics/attachments.rst
@@ -24,7 +24,7 @@ to one of its test files.
     In [1]: pdf.attachments
 
 This creates an attached file named ``README.md``, which holds the data in ``filespec``.
-Now we can retrive the data.
+Now we can retrieve the data.
 
 .. ipython::
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ cflags_defined = bool(environ.get('CFLAGS', ''))
 
 if not cflags_defined:
     if qpdf_source_tree:
-        # Point this to qpdf source tree built with shared libaries
+        # Point this to qpdf source tree built with shared libraries
         extra_includes.append(join(qpdf_source_tree, 'include'))
         extra_library_dirs.append(join(qpdf_source_tree, 'libqpdf/build/.libs'))
 

--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -1012,7 +1012,7 @@ class Extend_Page:
                 content stream to ensure that the overlay is rendered correctly.
                 Officially PDF limits the graphics stack depth to 32. Most
                 viewers will tolerate more, but excessive pushes may cause problems.
-                Multiple content streams may also be coalseced into a single content
+                Multiple content streams may also be coalesced into a single content
                 stream where this parameter is True, since the PDF specification
                 permits PDF writers to coalesce streams as they see fit.
             shrink: If True (default), allow the object to shrink to fit inside the

--- a/src/pikepdf/models/outlines.py
+++ b/src/pikepdf/models/outlines.py
@@ -179,7 +179,7 @@ class OutlineItem:
                 # 12.3.2.2 Named destination, byte string reference to Names
                 dest = f'<Named Destination in document .Root.Names dictionary: {self.destination}>'
             elif isinstance(self.destination, Name):
-                # 12.3.2.2 Named desintation, name object (PDF 1.1)
+                # 12.3.2.2 Named destination, name object (PDF 1.1)
                 dest = f'<Named Destination in document .Root.Dests dictionary: {self.destination}>'
             elif isinstance(self.destination, int):
                 # Page number

--- a/src/pikepdf/objects.py
+++ b/src/pikepdf/objects.py
@@ -111,10 +111,10 @@ class Name(Object, metaclass=_NameObjectMeta):
         This function uses Python's secrets.token_urlsafe, which returns a
         URL-safe encoded random number of the desired length. An optional
         *prefix* may be prepended. (The encoding is ultimately done with
-        :func:`base64.urlsafe_b64encode`.) Serendipitiously, URL-safe is also
+        :func:`base64.urlsafe_b64encode`.) Serendipitously, URL-safe is also
         PDF-safe.
 
-        When the length paramater is 16 (16 random bytes or 128 bits), the result
+        When the length parameter is 16 (16 random bytes or 128 bits), the result
         is probably globally unique and can be treated as never colliding with
         other names.
 

--- a/src/qpdf/job.cpp
+++ b/src/qpdf/job.cpp
@@ -27,7 +27,7 @@ void init_job(py::module_ &m)
         Provides access to the QPDF job interface.
 
         All of the functionality of the ``qpdf`` command line program
-        is now available to pikepdf through jobs.        
+        is now available to pikepdf through jobs.
 
         For further details:
             https://qpdf.readthedocs.io/en/stable/qpdf-job.html
@@ -45,7 +45,7 @@ void init_job(py::module_ &m)
             "Exit code for a job that had an error.")
         .def_readonly_static("EXIT_WARNING",
             &QPDFJob::EXIT_WARNING,
-            "Exit code for a job that had a warrning.")
+            "Exit code for a job that had a warning.")
         .def_readonly_static("EXIT_IS_NOT_ENCRYPTED",
             &QPDFJob::EXIT_IS_NOT_ENCRYPTED,
             "Exit code for a job that provide a password when the input was not "
@@ -81,7 +81,7 @@ void init_job(py::module_ &m)
             py::arg("progname") = "pikepdf",
             R"~~~(
                 Create a Job from command line arguments to the qpdf program.
-                
+
                 The first item in the ``args`` list should be equal to ``progname``,
                 whose default is ``"pikepdf"``.
 
@@ -111,8 +111,8 @@ void init_job(py::module_ &m)
         .def_property_readonly("exit_code",
             &QPDFJob::getExitCode,
             R"~~~(
-            After run(), returns an integer exit code. 
-            
+            After run(), returns an integer exit code.
+
             Some exit codes have integer value. Their applicably is determined by
             context of the job being run.
             )~~~")

--- a/src/qpdf/object.cpp
+++ b/src/qpdf/object.cpp
@@ -42,7 +42,7 @@ PDF semantics dictate that setting a dictionary key to Null deletes the key.
 
     d['/Key'] = None  # would delete /Key
 
-For Python users appears to have an unxpected side effect, so this action is
+For Python users appears to have an unexpected side effect, so this action is
 prohibited. You cannot set keys to None.
 
 pikepdf.String is a "type" that can be converted with str() or bytes() as
@@ -115,7 +115,7 @@ bool objecthandle_equal(QPDFObjectHandle self, QPDFObjectHandle other)
         return result;
     }
 
-    // Apart from numeric types, disimilar types are never equal
+    // Apart from numeric types, dissimilar types are never equal
     if (self_typecode != other_typecode)
         return false;
 

--- a/src/qpdf/parsers.h
+++ b/src/qpdf/parsers.h
@@ -48,7 +48,7 @@ public:
 };
 
 // Used for parse_content_stream. Handles each object by grouping into operands
-// and operators. The whole parse stream can be retrived at once.
+// and operators. The whole parse stream can be retrieved at once.
 class OperandGrouper : public QPDFObjectHandle::ParserCallbacks {
 public:
     OperandGrouper(const std::string &operators);

--- a/src/qpdf/qpdf.cpp
+++ b/src/qpdf/qpdf.cpp
@@ -449,7 +449,7 @@ void save_pdf(QPDF &q,
 
     if (preserving_encryption) {
         if (!q.isEncrypted()) {
-            throw py::value_error("can't perserve encryption parameters on "
+            throw py::value_error("can't preserve encryption parameters on "
                                   "a file with no encryption");
         }
         w.setPreserveEncryption(true); // Keep existing encryption
@@ -522,7 +522,7 @@ void init_qpdf(py::module_ &m)
                 qpdf_basic_settings(*q);
                 return q;
             },
-            "Create a new empty PDF from stratch.")
+            "Create a new empty PDF from scratch.")
         .def_static("_open",
             open_pdf,
             py::arg("filename_or_stream"),
@@ -719,7 +719,7 @@ void init_qpdf(py::module_ &m)
             After deleting content from a PDF such as pages, objects related
             to that page, such as images on the page, may still be present.
 
-            Retun type:
+            Return type:
                 pikepdf._qpdf._ObjectList
             )~~~",
             py::return_value_policy::reference_internal)

--- a/src/qpdf/tokenfilter.cpp
+++ b/src/qpdf/tokenfilter.cpp
@@ -128,7 +128,7 @@ void init_tokenfilter(py::module_ &m)
                 (unless an exception is raised).
 
                 If this method raises an exception, the exception will be
-                caught by C++, consumed, and repalced with a less informative
+                caught by C++, consumed, and replaced with a less informative
                 exception. Use :meth:`pikepdf.Pdf.get_warnings` to view the
                 original.
 


### PR DESCRIPTION
This PR fixes some small typos across the project's docs and comments.