### PR TITLE
docs: fix typo

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -135,7 +135,7 @@ page dictionary that provides many useful functions for working on pages.
 repr() output
 -------------
 
-Let's example the page's ``repr()`` output:
+Let's observe the page's ``repr()`` output:
 
 .. ipython::
 


### PR DESCRIPTION
Fixes a small typo I came across when reading the tutorial.

---

(PS: Really lovely library! It was a breeze to use.)