### PR TITLE
Enable building Python 3.11 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,8 @@ exclude = '''
 test-command = "pytest -nauto {project}/tests"
 test-extras = "test"
 # cp36: ancient
-# cp311: too many missing deps
 # pp39: no Pillow pp39 wheels yet - https://pypi.org/project/Pillow/#files
-skip = ["cp36-*", "cp311-*", "pp39-*", "*musllinux*", "pp*-manylinux*_aarch64"]
+skip = ["cp36-*", "pp39-*", "*musllinux*", "pp*-manylinux*_aarch64"]
 test-skip = "*_arm64 *_universal2:arm64"
 
 [tool.cibuildwheel.environment]


### PR DESCRIPTION
It'd be nice to enable this, but it looks like it's crashing due to https://github.com/python/cpython/issues/96046 So this is more of a reminder for later.