### PR TITLE
use setDeterministicID() from qpdf to produce bit-by-bit identical output without dropping the /ID

### DIFF
--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -506,6 +506,7 @@ class Extend_Pdf:
         progress: Callable[[int], None] = None,
         encryption: Encryption | bool | None = None,
         recompress_flate: bool = False,
+        deterministic_id: bool = False,
     ) -> None:
         """
         Save all modifications to this :class:`pikepdf.Pdf`.
@@ -522,8 +523,10 @@ class Extend_Pdf:
 
             static_id: Indicates that the ``/ID`` metadata, normally
                 calculated as a hash of certain PDF contents and metadata
-                including the current time, should instead be generated
-                deterministically. Normally for debugging.
+                including the current time, should instead be set to a static
+                value. Only use this for debugging and testing. Use
+                ``deterministic_id`` if you want to get the same ``/ID`` for
+                the same document contents.
             preserve_pdfa: Ensures that the file is generated in a
                 manner compliant with PDF/A and other stricter variants.
                 This should be True, the default, in most cases.
@@ -597,6 +600,14 @@ class Extend_Pdf:
                 Alternately, an ``Encryption`` object may be provided that
                 sets the parameters for new encryption.
 
+            deterministic_id: Indicates that the ``/ID`` metadata, normally
+                calculated as a hash of certain PDF contents and metadata
+                including the current time, should instead be computed using
+                only deterministic data like the file contents. At a small
+                runtime cost, this enables generation of the same ``/ID`` if
+                the same inputs are converted in the same way multiple times.
+                Does not work for encrypted files.
+
         Raises:
             PdfError
             ForeignObjectError
@@ -656,6 +667,7 @@ class Extend_Pdf:
             encryption=encryption,
             samefile_check=getattr(self, '_tmp_stream', None) is None,
             recompress_flate=recompress_flate,
+            deterministic_id=deterministic_id,
         )
 
     @staticmethod

--- a/src/pikepdf/_qpdf.pyi
+++ b/src/pikepdf/_qpdf.pyi
@@ -566,6 +566,7 @@ class Pdf:
         progress: Callable[[int], None] = None,
         encryption: Encryption | bool | None = None,
         recompress_flate: bool = False,
+        deterministic_id: bool = False,
     ) -> None: ...
     def show_xref_table(self) -> None: ...
     @property

--- a/src/qpdf/qpdf.cpp
+++ b/src/qpdf/qpdf.cpp
@@ -366,13 +366,17 @@ void save_pdf(QPDF &q,
     py::object progress                     = py::none(),
     py::object encryption                   = py::none(),
     bool samefile_check                     = true,
-    bool recompress_flate                   = false)
+    bool recompress_flate                   = false,
+    bool deterministic_id                   = false)
 {
     std::string description;
     QPDFWriter w(q);
 
     if (static_id) {
         w.setStaticID(true);
+    }
+    if (deterministic_id) {
+        w.setDeterministicID(true);
     }
     w.setNewlineBeforeEndstream(preserve_pdfa);
 
@@ -687,7 +691,8 @@ void init_qpdf(py::module_ &m)
             py::arg("progress")             = py::none(),
             py::arg("encryption")           = py::none(),
             py::arg("samefile_check")       = true,
-            py::arg("recompress_flate")     = false)
+            py::arg("recompress_flate")     = false,
+            py::arg("deterministic_id")     = false)
         .def("_get_object_id", &QPDF::getObjectByID)
         .def(
             "get_object",

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -161,10 +161,10 @@ class TestStreams:
 
     def test_save_stream(self, trivial, outdir):
         pdf = trivial
-        pdf.save(outdir / 'nostream.pdf', static_id=True)
+        pdf.save(outdir / 'nostream.pdf', deterministic_id=True)
 
         bio = BytesIO()
-        pdf.save(bio, static_id=True)
+        pdf.save(bio, deterministic_id=True)
         bio.seek(0)
 
         with (outdir / 'nostream.pdf').open('rb') as saved_file:


### PR DESCRIPTION
We want to be able to create PDF files that are bit-by-bit identical if they share the same content. By default, the `ID` metadata will always differ because qpdf uses `QUtil::get_current_time()` as part of the values it hashes. Setting the `ID` metadata to a static value is a bad idea because it would not make the file in question uniquely identifiable anymore according to PDF 1.7 reference section 10.3 "File Identifiers".

Luckily for us, qpdf offers the `setDeterministicID()` function which avoids using the current time and the filename as input for the MD5 hash computation. This pull request exposes this functionality in pikepdf.

Fixes: https://gitlab.mister-muffin.de/josch/img2pdf/issues/150