### PR TITLE
Remove redundant license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ url = https://github.com/pikepdf/pikepdf
 author = James R. Barlow
 author_email = james@purplerock.ca
 license = MPL-2.0
-license_file = LICENSE.txt
 license_files =
     LICENSE.txt
     licenses-for-wheels.txt


### PR DESCRIPTION
Remove the `license_file` key from `setup.cfg`, as it is deprecated and redundant to `license_files` already present.  All setuptools version supported (as per the restriction in `pyproject.toml`) already support `license_files`.