### PR TITLE
fix `/K 0` in CCITTFaxDecode filter to have group 3 encoding

### DIFF
--- a/src/pikepdf/models/image.py
+++ b/src/pikepdf/models/image.py
@@ -721,7 +721,7 @@ class PdfImage(PdfImageBase):
         elif k > 0:
             ccitt_group = 3  # Group 3 2-D
         else:
-            ccitt_group = 2  # Group 3 1-D
+            ccitt_group = 3  # Group 3 1-D
         _black_is_one = self.decode_parms[0].get("/BlackIs1", False)
         # PDF spec says:
         # BlackIs1: A flag indicating whether 1 bits shall be interpreted as black


### PR DESCRIPTION
see discussion in https://github.com/pikepdf/pikepdf/issues/401

*NOTE*: although it fixes the problem with our test case, this needs to be inspected
https://github.com/pikepdf/pikepdf/pull/437#issuecomment-1414156176