### PR TITLE
DOC: Compare against pypdf - PyPDF2 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,21 @@ Features
 
 This library is similar to PyPDF2 and pdfrw - it provides low level access to PDF features and allows editing and content transformation of existing PDFs. Some knowledge of the PDF specification may be helpful. It does not have the capability to render a PDF to image.
 
-| **Feature**                                                         | **pikepdf**                                 | **PyPDF2**                                | **pdfrw**                               |
+| **Feature**                                                         | **pikepdf**                                 | **pypdf**                                | **pdfrw**                               |
 | ------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------- | --------------------------------------- |
 | Editing, manipulation and transformation of existing PDFs           | ✔                                           | ✔                                         | ✔                                       |
 | Based on an existing, mature PDF library                            | QPDF                                        | ✘                                         | ✘                                       |
 | Implementation                                                      | C++ and Python                              | Python                                    | Python                                  |
-| PDF versions supported                                              | 1.1 to 1.7                                  | 1.3?                                      | 1.7                                     |
-| Python versions supported                                           | 3.8-3.11 [^1]                               | 2.7-3.10                                  | 2.6-3.6                                 |
-| Save and load password protected (encrypted) PDFs                   | ✔ (except public key)                       | ✘ (Only obsolete RC4)                     | ✘ (not at all)                          |
-| Save and load PDF compressed object streams (PDF 1.5)               | ✔                                           | ✘                                         | ✘                                       |
+| PDF versions supported                                              | 1.1 to 1.7                                  | 1.1 to 1.7                                | 1.7                                     |
+| Python versions supported                                           | 3.8-3.11 [^1]                               | 3.6-3.11                                  | 2.6-3.6                                 |
+| Save and load password protected (encrypted) PDFs                   | ✔ (except public key)                       | ✔                                         | ✘ (not at all)                          |
+| Save and load PDF compressed object streams (PDF 1.5)               | ✔                                           | ✔                                         | ✘                                       |
 | Creates linearized ("fast web view") PDFs                           | ✔                                           | ✘                                         | ✘                                       |
-| Actively maintained                                                 | ![pikepdf commit activity][pikepdf-commits] | ![PyPDF2 commit activity][pypdf2-commits] | ![pdfrw commit activity][pdfrw-commits] |
+| Actively maintained                                                 | ![pikepdf commit activity][pikepdf-commits] | ![pypdf commit activity][pypdf-commits] | ![pdfrw commit activity][pdfrw-commits] |
 | Test suite coverage                                                 | ![codecov][codecov]                         | ![codecovpypdf2][codecovpypdf]            | unknown                                 |
 | Creates PDFs that pass PDF validation tests                         | ✔                                           | ✘                                         | ?                                       |
 | Modifies PDF/A without breaking PDF/A compliance                    | ✔                                           | ✘                                         | ?                                       |
-| Automatically repairs PDFs with internal errors                     | ✔                                           | ✘                                         | ✘                                       |
+| Automatically repairs PDFs with internal errors                     | ✔                                           | ✔                                         | ✘                                       |
 | PDF XMP metadata editing                                            | ✔                                           | read-only                                 | ✘                                       |
 | Documentation                                                       | ✔                                           | ✔                                         | ✔                                       |
 | Integrates with Jupyter and IPython notebooks for rapid development | ✔                                           | ✘                                         | ✘                                       |
@@ -60,13 +60,13 @@ This library is similar to PyPDF2 and pdfrw - it provides low level access to PD
 
 [pikepdf-commits]: https://img.shields.io/github/commit-activity/y/pikepdf/pikepdf.svg
 
-[pypdf2-commits]: https://img.shields.io/github/commit-activity/y/mstamy2/PyPDF2.svg
+[pypdf2-commits]: https://img.shields.io/github/commit-activity/y/py-pdf/pypdf.svg
 
 [pdfrw-commits]: https://img.shields.io/github/commit-activity/y/pmaupin/pdfrw.svg
 
 [codecov]: https://codecov.io/gh/pikepdf/pikepdf/branch/master/graph/badge.svg?token=8FJ755317J
 
-[codecovpypdf]: https://codecov.io/gh/py-pdf/PyPDF2/branch/main/graph/badge.svg?token=id42cGNZ5Z
+[codecovpypdf]: https://codecov.io/gh/py-pdf/pypdf/branch/main/graph/badge.svg?token=id42cGNZ5Z
 
 Testimonials
 ------------


### PR DESCRIPTION
* PyPDF2 moved to pypdf: https://pypi.org/project/PyPDF2/