### PR TITLE
fix PdfImage.extract_to: mkdir

### DIFF
--- a/src/pikepdf/models/image.py
+++ b/src/pikepdf/models/image.py
@@ -668,6 +668,7 @@ class PdfImage(PdfImageBase):
         extension = self._extract_to_stream(stream=bio)
         bio.seek(0)
         filepath = Path(str(Path(fileprefix)) + extension)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
         with filepath.open('wb') as target:
             copyfileobj(bio, target)
         return str(filepath)


### PR DESCRIPTION
error was

```py
pdfimage.extract_to("somedir/somefile")
```

```
Traceback (most recent call last):
  File "/nix/store/hcy71py66cd1syy13c27g46lbj469znn-python3.10-pikepdf-7.1.1/lib/python3.10/site-packages/pikepdf/models/image.py", line 672, in extract_to
    with filepath.open('wb') as target:
  File "/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: 'somedir/somefile.jpg'
```