### PR TITLE
Expose QPDFJob::createQPDF and QPDFJob::writeQPDF

### DIFF
--- a/src/core/job.cpp
+++ b/src/core/job.cpp
@@ -112,6 +112,10 @@ void init_job(py::module_ &m)
             &QPDFJob::setMessagePrefix,
             "Allows manipulation of the prefix in front of all output messages.")
         .def("run", &QPDFJob::run, "Executes the job.")
+        .def("create_pdf",
+             [](QPDFJob &job) { return std::shared_ptr<QPDF>(job.createQPDF()); },
+             "Executes the first stage of the job.")
+        .def("write_pdf", &QPDFJob::writeQPDF, py::arg("pdf"), "Executes the second stage of the job.")
         .def_property_readonly("has_warnings",
             &QPDFJob::hasWarnings,
             "After run(), returns True if there were warnings.")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -7,7 +7,7 @@ import json
 
 import pytest
 
-from pikepdf import Job, JobUsageError
+from pikepdf import Job, JobUsageError, Pdf
 
 
 def test_job_from_argv(resources):
@@ -41,6 +41,18 @@ def test_job_from_json(resources, outpdf):
     job.run()
     assert job.exit_code == 0
 
+def test_job_in_stages(resources, outpdf):
+    job_json = {}
+    job_json['inputFile'] = str(resources / 'outlines.pdf')
+    job_json['outputFile'] = str(outpdf)
+    job = Job(json.dumps(job_json))
+    job.check_configuration()
+    pdf = job.create_pdf()
+    del pdf.pages[1]
+    job.write_pdf(pdf)
+    assert job.exit_code == 0
+    with Pdf.open(outpdf) as pdf:
+        assert len(pdf.pages) == 1
 
 def test_job_from_invalid_json():
     job_json = {}


### PR DESCRIPTION
in order to make it easier to use pikepdf for customizing QPDF jobs.

Requires qpdf 11.4