### PR TITLE
Fix typo in doc comment

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -41,8 +41,8 @@ PDF semantics dictate that setting a dictionary key to Null deletes the key.
 
     d['/Key'] = None  # would delete /Key
 
-For Python users appears to have an unexpected side effect, so this action is
-prohibited. You cannot set keys to None.
+For Python users this would be unexpected, so this action is prohibited.
+You cannot set keys to None.
 
 pikepdf.String is a "type" that can be converted with str() or bytes() as
 needed.


### PR DESCRIPTION
Or some other wording. At the moment the sentence is not grammatically complete.