### PR TITLE
Fix def of Object.to_json

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -855,8 +855,8 @@ void init_object(py::module_ &m)
                 int schema_version = 2) -> py::bytes {
                 return h.getJSON(schema_version, dereference).unparse();
             },
-            py::arg("schema_version") = 2,
             py::arg("dereference")    = false,
+            py::arg("schema_version") = 2,
             R"~~~(
             Convert to a QPDF JSON representation of the object.
 


### PR DESCRIPTION
Existing def generates misleading  documentation:

to_json(self: pikepdf.Object, schema_version: bool = 2,
        dereference: int = False) → byte