### PR TITLE
Adds new job to create a release and upload assets to it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,32 @@ jobs:
           password: ${{ secrets.TOKEN_PYPI }}
           # repository_url: https://test.pypi.org/legacy/
 
+  create_release:
+    name: Create GitHub release
+    needs: [wheels_linux, wheels_macos, wheels_windows, wheels_macos_arm, wheels_linux_arm, sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    permissions:
+      # Required to create a release
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: Create Release
+        id: create-release
+        uses: shogo82148/actions-create-release@v1
+
+      - name: Upload Assets
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
+
   trigger_rtd:
     name: Trigger ReadTheDocs
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a new job which creates a GitHub release, with the built assets attached and a link to at least the release notes document in the tag.  There are a lot of wheels, so it could be restricted to just the sdist or no assets at all, just the release with a body.

For an example of what it looks like: https://github.com/stumpylog/pikepdf/releases

Helps #488 with some further visibly and ability to subscribes to new releases.