### PR TITLE
remove use relative imports

### DIFF
--- a/src/pikepdf/__init__.py
+++ b/src/pikepdf/__init__.py
@@ -7,15 +7,15 @@
 
 from __future__ import annotations
 
-from ._version import __version__
+from pikepdf._version import __version__
 
 try:
-    from . import _core
+    from pikepdf import _core
 except ImportError as _e:  # pragma: no cover
     _msg = "pikepdf's extension library failed to import"
     raise ImportError(_msg) from _e
 
-from ._core import (
+from pikepdf._core import (
     AccessMode,
     Annotation,
     AttachedFileSpec,
@@ -41,8 +41,8 @@ from ._core import (
     TokenFilter,
     TokenType,
 )
-from ._exceptions import DependencyError
-from .objects import (
+from pikepdf._exceptions import DependencyError
+from pikepdf.objects import (
     Array,
     Dictionary,
     Name,
@@ -52,7 +52,7 @@ from .objects import (
     Stream,
     String,
 )
-from .models import (
+from pikepdf.models import (
     Encryption,
     Outline,
     OutlineItem,
@@ -73,8 +73,8 @@ from .models import (
 # While _cpphelpers is intended to be called from our C++ code only, explicitly
 # importing helps introspection tools like PyInstaller figure out that the module
 # is necessary.
-from . import _cpphelpers, _methods, codec  # noqa: F401, F841
-from . import settings
+from pikepdf import _cpphelpers, _methods, codec  # noqa: F401, F841
+from pikepdf import settings
 
 __libqpdf_version__: str = _core.qpdf_version()
 

--- a/src/pikepdf/codec.py
+++ b/src/pikepdf/codec.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import codecs
 from typing import Any, Container
 
-from ._core import pdf_doc_to_utf8, utf8_to_pdf_doc
+from pikepdf._core import pdf_doc_to_utf8, utf8_to_pdf_doc
 
 # pylint: disable=redefined-builtin
 

--- a/src/pikepdf/models/__init__.py
+++ b/src/pikepdf/models/__init__.py
@@ -5,18 +5,18 @@
 
 from __future__ import annotations
 
-from ._content_stream import (
+from pikepdf.models._content_stream import (
     ContentStreamInstructions,
     PdfParsingError,
     UnparseableContentStreamInstructions,
     parse_content_stream,
     unparse_content_stream,
 )
-from .encryption import Encryption, EncryptionInfo, Permissions
-from .image import PdfImage, PdfInlineImage, UnsupportedImageTypeError
-from .matrix import PdfMatrix
-from .metadata import PdfMetadata
-from .outlines import (
+from pikepdf.models.encryption import Encryption, EncryptionInfo, Permissions
+from pikepdf.models.image import PdfImage, PdfInlineImage, UnsupportedImageTypeError
+from pikepdf.models.matrix import PdfMatrix
+from pikepdf.models.metadata import PdfMetadata
+from pikepdf.models.outlines import (
     Outline,
     OutlineItem,
     OutlineStructureError,

--- a/src/pikepdf/objects.py
+++ b/src/pikepdf/objects.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 from secrets import token_urlsafe
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
-from . import _core
-from ._core import Matrix, Object, ObjectType, Rectangle
+from pikepdf import _core
+from pikepdf._core import Matrix, Object, ObjectType, Rectangle
 
 if TYPE_CHECKING:  # pragma: no cover
     from pikepdf import Pdf

--- a/src/pikepdf/settings.py
+++ b/src/pikepdf/settings.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from ._core import (
+from pikepdf._core import (
     get_decimal_precision,
     set_decimal_precision,
     set_flate_compression_level,


### PR DESCRIPTION
Fixes #552

Use relative imports which blocks use test suite using "test as installed" methodoloby where tested module code path is passed over $PYTHONPATH. This methodology typically is used on packaging.