### PR TITLE
Fix test_pages_wrong_type

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -371,7 +371,7 @@ def test_remove_by_ref(fourpages):
 
 
 def test_pages_wrong_type(fourpages):
-    with pytest.raises(TypeError), pytest.deprecated_call():
+    with pytest.raises(TypeError):
         fourpages.pages.insert(3, {})
     with pytest.raises(TypeError), pytest.deprecated_call():
         fourpages.pages.insert(3, Array([42]))

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -375,6 +375,8 @@ def test_pages_wrong_type(fourpages):
         fourpages.pages.insert(3, {})
     with pytest.raises(TypeError), pytest.deprecated_call():
         fourpages.pages.insert(3, Array([42]))
+    with pytest.deprecated_call():
+        fourpages.pages.insert(3, Dictionary(Type=Name.Page))
 
 
 def test_page_splitting_generator(resources, tmp_path):


### PR DESCRIPTION
Test fails with pytest-8.0.0 with message:

Failed: DID NOT WARN. No warnings of type (<class 'DeprecationWarning'>, <class 'PendingDeprecationWarning'>, <class 'FutureWarning'>) were emitted. 
Emitted warnings: [].