### PR TITLE
Change QPDF to qpdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ pikepdf
 
 [![Build Status](https://github.com/pikepdf/pikepdf/actions/workflows/build.yml/badge.svg)](https://github.com/pikepdf/pikepdf/actions/workflows/build.yml) [![PyPI](https://img.shields.io/pypi/v/pikepdf.svg)](https://pypi.org/project/pikepdf/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pikepdf) ![PyPy](https://img.shields.io/badge/3.9-blue) ![PyPI - License](https://img.shields.io/pypi/l/pikepdf) ![PyPI - Downloads](https://img.shields.io/pypi/dm/pikepdf)  [![codecov](https://codecov.io/gh/pikepdf/pikepdf/branch/main/graph/badge.svg?token=8FJ755317J)](https://codecov.io/gh/pikepdf/pikepdf)
 
-pikepdf is based on [QPDF](https://github.com/qpdf/qpdf), a powerful PDF manipulation and repair library.
+pikepdf is based on [qpdf](https://github.com/qpdf/qpdf), a powerful PDF manipulation and repair library.
 
-Python + QPDF = "py" + "qpdf" = "pyqpdf", which looks like a dyslexia test. Say it out loud, and it sounds like "pikepdf".
+Python + qpdf = "py" + "qpdf" = "pyqpdf", which looks like a dyslexia test. Say it out loud, and it sounds like "pikepdf".
 
 ```python
 # Elegant, Pythonic API
@@ -37,19 +37,19 @@ Features
 
 This library is similar to pypdf (formerly PyPDF2) - it provides low level access to PDF features and allows editing and content transformation of existing PDFs. Some knowledge of the PDF specification may be helpful. It does not have the capability to render a PDF to image.
 
-| **Feature**                                                         | **pikepdf**                                 | **pypdf** (PyPDF2)                        |
-| ------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------- |
-| Editing, manipulation and transformation of existing PDFs           | ✔                                           | ✔                                         |
-| Based on an existing, mature PDF library                            | QPDF                                        | ✘                                         |
-| Implementation                                                      | C++ and Python                              | Python                                    |
-| PDF versions supported                                              | 1.1 to 1.7                                  | 1.1 to 1.7                                |
-| Save and load password protected (encrypted) PDFs                   | ✔ (except public key)                       | ✔ (except public key)                     |
-| Creates linearized ("fast web view") PDFs                           | ✔                                           | ✘                                         |
-| Test suite coverage                                                 | ![codecov][codecov]                         | ![codecovpypdf2][codecovpypdf]            |
-| Creates PDFs that pass PDF validation tests                         | ✔                                           | ✘                                         |
-| Modifies PDF/A without breaking PDF/A compliance                    | ✔                                           | ✘                                         |
-| PDF XMP metadata editing                                            | ✔                                           | read-only                                 |
-| Integrates with Jupyter and IPython notebooks for rapid development | ✔                                           | ✘                                         |
+| **Feature**                                                         | **pikepdf**           | **pypdf** (PyPDF2)                        |
+| ------------------------------------------------------------------- |-----------------------| ----------------------------------------- |
+| Editing, manipulation and transformation of existing PDFs           | ✔                     | ✔                                         |
+| Based on an existing, mature PDF library                            | qpdf                  | ✘                                         |
+| Implementation                                                      | C++ and Python        | Python                                    |
+| PDF versions supported                                              | 1.1 to 1.7            | 1.1 to 1.7                                |
+| Save and load password protected (encrypted) PDFs                   | ✔ (except public key) | ✔ (except public key)                     |
+| Creates linearized ("fast web view") PDFs                           | ✔                     | ✘                                         |
+| Test suite coverage                                                 | ![codecov][codecov]   | ![codecovpypdf2][codecovpypdf]            |
+| Creates PDFs that pass PDF validation tests                         | ✔                     | ✘                                         |
+| Modifies PDF/A without breaking PDF/A compliance                    | ✔                     | ✘                                         |
+| PDF XMP metadata editing                                            | ✔                     | read-only                                 |
+| Integrates with Jupyter and IPython notebooks for rapid development | ✔                     | ✘                                         |
 
 [codecov]: https://codecov.io/gh/pikepdf/pikepdf/branch/main/graph/badge.svg?token=8FJ755317J
 
@@ -58,7 +58,7 @@ This library is similar to pypdf (formerly PyPDF2) - it provides low level acces
 Testimonials
 ------------
 
-> I decided to try writing a quick Python program with pikepdf to automate [something] and it "just worked". –Jay Berkenbilt, creator of QPDF
+> I decided to try writing a quick Python program with pikepdf to automate [something] and it "just worked". –Jay Berkenbilt, creator of qpdf
 
 > "Thanks for creating a great pdf library, I tested out several and this is the one that was best able to work with whatever I threw at it." –@cfcurtis
 

--- a/licenses-for-wheels.txt
+++ b/licenses-for-wheels.txt
@@ -613,10 +613,10 @@ Apache License 2.0
    limitations under the License.
 
 
-QPDF NOTICE
+qpdf NOTICE
 ===========
 
-QPDF is copyright (c) 2005-2018 Jay Berkenbilt
+qpdf is copyright (c) 2005-2024 Jay Berkenbilt
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ before-all = [
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx*x86_64"
 inherit.environment = "append"
-# QPDF requires C++17 which is not fully supported on macOS < 11.0.
+# qpdf requires C++17 which is not fully supported on macOS < 11.0.
 environment.MACOSX_DEPLOYMENT_TARGET = "12.0"
 # When MACOSX_DEPLOYMENT_TARGET is >= 11.0, set this to 0
 # to ensure that pip/auditwheel generate the correct version stamp.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if qpdf_source_tree:
 cflags_defined = bool(environ.get('CFLAGS', ''))
 shims_enabled = not cflags_defined
 
-# If shims are enabled, we add some known locations where QPDF and other third party
+# If shims are enabled, we add some known locations where qpdf and other third party
 # libraries might be installed, in hopes the build will succeed if we suggest the
 # obvious.
 if shims_enabled and not qpdf_source_tree:

--- a/src/core/annotation.cpp
+++ b/src/core/annotation.cpp
@@ -20,13 +20,13 @@ void init_annotation(py::module_ &m)
         .def(py::init<QPDFObjectHandle &>(), py::keep_alive<0, 1>())
         .def_property_readonly("subtype",
             [](QPDFAnnotationObjectHelper &anno) {
-                // Don't use QPDF because the method returns std::string
+                // Don't use qpdf because the method returns std::string
                 return anno.getObjectHandle().getKey("/Subtype");
             })
         .def_property_readonly("flags", &QPDFAnnotationObjectHelper::getFlags)
         .def_property_readonly("appearance_state",
             [](QPDFAnnotationObjectHelper &anno) {
-                // Don't use QPDF because the method returns std::string
+                // Don't use qpdf because the method returns std::string
                 auto key = anno.getObjectHandle().getKey("/AS");
                 if (key.isName())
                     return key;

--- a/src/core/jbig2-inl.h
+++ b/src/core/jbig2-inl.h
@@ -43,7 +43,7 @@ public:
         try {
             extracted = extract_jbig2(pydata, this->jbig2globals);
         } catch (py::error_already_set &e) {
-            // In QPDF over here...
+            // In qpdf over here...
             // https://github.com/qpdf/qpdf/blob/dd3b2cedd3164692925df1ef7414eb452343372f/libqpdf/QPDF.cc#L2955-2984
             // all exceptions that happen during Pipeline::finish() will be trapped
             // and converted into a generic error about the object being not decodable.

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -4,7 +4,7 @@
 #include "pikepdf.h"
 #include <qpdf/QPDFLogger.hh>
 
-// Pipeline to relay QPDF log messages to Python logging module
+// Pipeline to relay qpdf log messages to Python logging module
 // This is a sink - cannot pass to other pipeline objects
 class Pl_PythonLogger : public Pipeline {
 public:
@@ -53,11 +53,11 @@ void init_logger(py::module_ &m)
     auto py_logger = py::module_::import("logging").attr("getLogger")("pikepdf._core");
 
     std::shared_ptr<Pipeline> pl_log_info = std::make_shared<Pl_PythonLogger>(
-        "QPDF to Python logging pipeline", py_logger, "info");
+        "qpdf to Python logging pipeline", py_logger, "info");
     std::shared_ptr<Pipeline> pl_log_warn = std::make_shared<Pl_PythonLogger>(
-        "QPDF to Python logging pipeline", py_logger, "warning");
+        "qpdf to Python logging pipeline", py_logger, "warning");
     std::shared_ptr<Pipeline> pl_log_error = std::make_shared<Pl_PythonLogger>(
-        "QPDF to Python logging pipeline", py_logger, "error");
+        "qpdf to Python logging pipeline", py_logger, "error");
 
     auto pikepdf_logger = get_pikepdf_logger();
     pikepdf_logger->setInfo(pl_log_info);

--- a/src/core/matrix.cpp
+++ b/src/core/matrix.cpp
@@ -54,7 +54,7 @@ void init_matrix(py::module_ &m)
                 throw py::value_error(
                     "pikepdf.Object could not be converted to Matrix");
             }
-            // QPDF defines an older class, QPDFObjectHandle::Matrix,
+            // qpdf defines an older class, QPDFObjectHandle::Matrix,
             // for interop with QPDFObjectHandle. We want to ignore it as
             // much as possible, but here, only the older class has the
             // right function.

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -28,9 +28,9 @@ Type table
 
 See objects.rst. In short and with technical details:
 
-These QPDF types are directly mapped to a native Python equivalent. The C++
+These qpdf types are directly mapped to a native Python equivalent. The C++
 object is never returned to Python; a Python object is returned instead.
-Adding one of these to a QPDF container type causes the appropriate conversion.
+Adding one of these to a qpdf container type causes the appropriate conversion.
     Boolean <-> bool
     Integer <-> int
     Real <-> Decimal
@@ -161,7 +161,7 @@ bool objecthandle_equal(QPDFObjectHandle self, QPDFObjectHandle other)
         auto self_buffer  = self.getRawStreamData();
         auto other_buffer = other.getRawStreamData();
 
-        // Early out: if underlying QPDF Buffers happen to be the same, the data is
+        // Early out: if underlying qpdf Buffers happen to be the same, the data is
         // the same
         if (self_buffer == other_buffer)
             return true;
@@ -273,7 +273,7 @@ std::shared_ptr<Buffer> get_stream_data(
     try {
         return h.getStreamData(decode_level);
     } catch (const QPDFExc &e) {
-        // Make a new exception that has the objgen info, since QPDF's
+        // Make a new exception that has the objgen info, since qpdf's
         // will not
         std::string msg = e.getMessageDetail();
         str_replace(msg, "getStreamData", "read_bytes");

--- a/src/core/object_repr.cpp
+++ b/src/core/object_repr.cpp
@@ -274,7 +274,7 @@ static std::string objecthandle_repr_inner(QPDFObjectHandle h,
         break;
     // LCOV_EXCL_START
     default:
-        ss << "Unexpected QPDF object type value: " << h.getTypeCode();
+        ss << "Unexpected qpdf object type value: " << h.getTypeCode();
         break;
         // LCOV_EXCL_STOP
     }

--- a/src/core/page.cpp
+++ b/src/core/page.cpp
@@ -136,7 +136,7 @@ void init_page(py::module_ &m)
                 poh.filterContents(&tf, &pl_buffer);
 
                 // Hold .getBuffer in unique_ptr to ensure it is deleted.
-                // QPDF makes a copy and expects us to delete it.
+                // qpdf makes a copy and expects us to delete it.
                 std::unique_ptr<Buffer> buf(pl_buffer.getBuffer());
                 auto data = reinterpret_cast<const char *>(buf->getBuffer());
                 auto size = buf->getSize();

--- a/src/core/pikepdf.cpp
+++ b/src/core/pikepdf.cpp
@@ -115,7 +115,7 @@ PYBIND11_MODULE(_core, m)
     // py::options options;
     // options.disable_function_signatures();
 
-    m.doc()            = "pikepdf provides a Pythonic interface for QPDF";
+    m.doc()            = "pikepdf provides a Pythonic interface for qpdf";
     m.attr("__name__") = "pikepdf._core";
     m.def("qpdf_version", &QPDF::QPDFVersion, "Get libqpdf version");
 
@@ -146,7 +146,7 @@ PYBIND11_MODULE(_core, m)
         .def(
             "log_info",
             [](std::string s) { return get_pikepdf_logger()->info(s); },
-            "Used to test routing of QPDF's logger to Python logging.");
+            "Used to test routing of qpdf's logger to Python logging.");
 
     // -- Module level functions --
     m.def("utf8_to_pdf_doc",
@@ -162,7 +162,7 @@ PYBIND11_MODULE(_core, m)
         .def(
             "_translate_qpdf_logic_error",
             [](std::string s) { return translate_qpdf_logic_error(s).first; },
-            "Used to test interpretation of QPDF errors.")
+            "Used to test interpretation of qpdf errors.")
         .def("set_decimal_precision",
             [](uint prec) {
                 DECIMAL_PRECISION = prec;

--- a/src/pikepdf/_core.pyi
+++ b/src/pikepdf/_core.pyi
@@ -351,9 +351,9 @@ class Object:
     def same_owner_as(self, other: Object) -> bool:
         """Test if two objects are owned by the same :class:`pikepdf.Pdf`."""
     def to_json(self, dereference: bool = ..., schema_version: int = ...) -> bytes:
-        r"""Convert to a QPDF JSON representation of the object.
+        r"""Convert to a qpdf JSON representation of the object.
 
-        See the QPDF manual for a description of its JSON representation.
+        See the qpdf manual for a description of its JSON representation.
         https://qpdf.readthedocs.io/en/stable/json.html#qpdf-json-format
 
         Not necessarily compatible with other PDF-JSON representations that
@@ -637,8 +637,8 @@ class Annotation:
             forbidden_flags: The forbidden appearance flags. See PDF reference manual.
 
         Note:
-            This method is done mainly with QPDF. Its behavior may change when
-            different QPDF versions are used.
+            This method is done mainly with qpdf. Its behavior may change when
+            different qpdf versions are used.
         """
     @property
     def appearance_dict(self) -> Object:
@@ -1900,13 +1900,13 @@ class Pdf:
                 This should be True, the default, in most cases.
 
             min_version: Sets the minimum version of PDF
-                specification that should be required. If left alone QPDF
+                specification that should be required. If left alone qpdf
                 will decide. If a tuple, the second element is an integer, the
                 extension level. If the version number is not a valid format,
-                QPDF will decide what to do.
-            force_version: Override the version recommend by QPDF,
+                qpdf will decide what to do.
+            force_version: Override the version recommend by qpdf,
                 potentially creating an invalid file that does not display
-                in old versions. See QPDF manual for details. If a tuple, the
+                in old versions. See qpdf manual for details. If a tuple, the
                 second element is an integer, the extension level.
             fix_metadata_version: If ``True`` (default) and the XMP metadata
                 contains the optional PDF version field, ensure the version in
@@ -1970,7 +1970,7 @@ class Pdf:
                 As a drawback, it tends to make files larger.
 
             qdf: Save output QDF mode.  QDF mode is a special output
-                mode in QPDF to allow editing of PDFs in a text editor. Use
+                mode in qpdf to allow editing of PDFs in a text editor. Use
                 the program ``fix-qdf`` to fix convert back to a standard
                 PDF.
 
@@ -2200,7 +2200,7 @@ class Pdf:
         as needed.
 
         For every form field in the document, this generates appearance
-        streams, subject to the limitations of QPDF's ability to create
+        streams, subject to the limitations of qpdf's ability to create
         appearance streams.
 
         When invoked, this method will modify the ``Pdf`` in memory. It may be
@@ -2477,7 +2477,7 @@ class ContentStreamInlineImage:
     def iimage(self) -> PdfInlineImage: ...
 
 class Job:
-    """Provides access to the QPDF job interface.
+    """Provides access to the qpdf job interface.
 
     All of the functionality of the ``qpdf`` command line program
     is now available to pikepdf through jobs.
@@ -2496,14 +2496,14 @@ class Job:
     LATEST_JOB_JSON: ClassVar[int]
     """Version number of the most recent job-JSON schema."""
     LATEST_JSON: ClassVar[int]
-    """Version number of the most recent QPDF-JSON schema."""
+    """Version number of the most recent qpdf-JSON schema."""
 
     @staticmethod
     def json_out_schema(*, schema: int) -> str:
-        """For reference, the QPDF JSON output schema is built-in."""
+        """For reference, the qpdf JSON output schema is built-in."""
     @staticmethod
     def job_json_schema(*, schema: int) -> str:
-        """For reference, the QPDF job command line schema is built-in."""
+        """For reference, the qpdf job command line schema is built-in."""
     @overload
     def __init__(self, json: str) -> None: ...
     @overload

--- a/src/pikepdf/_cpphelpers.py
+++ b/src/pikepdf/_cpphelpers.py
@@ -78,7 +78,7 @@ LABEL_STYLE_MAP: dict[Name, Callable[[int], str]] = {
 
 
 def label_from_label_dict(label_dict: int | Dictionary) -> str:
-    """Convert a label dictionary returned by QPDF into a text string."""
+    """Convert a label dictionary returned by qpdf into a text string."""
     if isinstance(label_dict, int):
         return str(label_dict)
 

--- a/src/pikepdf/codec.py
+++ b/src/pikepdf/codec.py
@@ -16,7 +16,7 @@ from pikepdf._core import pdf_doc_to_utf8, utf8_to_pdf_doc
 # The following generates set of all Unicode code points that can be encoded in
 # pdfdoc. Since pdfdoc is 8-bit, the vast majority of code points cannot be.
 
-# Due to a bug, QPDF <= 10.5 and pikepdf < 5 had some inconsistencies around
+# Due to a bug, qpdf <= 10.5 and pikepdf < 5 had some inconsistencies around
 # PdfDocEncoding.
 PDFDOC_ENCODABLE = frozenset(
     list(range(0x00, 0x17 + 1))

--- a/src/pikepdf/models/image.py
+++ b/src/pikepdf/models/image.py
@@ -1043,10 +1043,10 @@ class PdfInlineImage(PdfImageBase):
 
     def read_bytes(self):
         """Return decompressed image bytes."""
-        # QPDF does not have an API to return this directly, so convert it.
+        # qpdf does not have an API to return this directly, so convert it.
         return self._convert_to_pdfimage().read_bytes()
 
     def get_stream_buffer(self):
         """Return decompressed stream buffer."""
-        # QPDF does not have an API to return this directly, so convert it.
+        # qpdf does not have an API to return this directly, so convert it.
         return self._convert_to_pdfimage().get_stream_buffer()


### PR DESCRIPTION
Refer to the qpdf project and library in lower-case, even at the start of sentences.