### PR TITLE
Add missing `#include <string>` to utils.h

### DIFF
--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 template <typename T, typename S>
 inline bool str_startswith(T haystack, S needle)
 {


### PR DESCRIPTION
src/core/utils.h uses symbols defined in `<string>`, but does not include the header.

This was detected and fixed by engineers applying Bazel's [`parse_headers`][1] feature to open-source code used at Google, and we'd like to contribute the fix.

[1]: https://bazel.build/docs/bazel-and-cpp#toolchain-features