### PR TITLE
Remove offending import, as raised by OSSFuzz

### DIFF
--- a/fuzzing/pikepdf_fuzzer.py
+++ b/fuzzing/pikepdf_fuzzer.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024 ennamarie19
 # SPDX-License-Identifier: MIT
-from __future__ import annotations
 
 import io
 import sys


### PR DESCRIPTION
As seen [here](https://github.com/google/oss-fuzz/actions/runs/10925247251/job/30326270598?pr=12454), the introduction of the future import causes the coverage build to fail. It seems that about 12 lines of code are injected to the head of the file during the OSS-Fuzz build process, making the inclusion of this import raise a syntaxerror.

This PR removes the offending import.