### PR TITLE
Set XMP properties as subelements instead of inline properties

### DIFF
--- a/src/pikepdf/models/metadata.py
+++ b/src/pikepdf/models/metadata.py
@@ -823,14 +823,15 @@ class PdfMetadata(MutableMapping):
             node = etree.SubElement(rdfdesc, self._qname(key))
             self._setitem_add_array(node, val)
         elif isinstance(val, str):
-            _rdfdesc = etree.SubElement(
-                rdf,
-                str(QName(XMP_NS_RDF, 'Description')),
-                attrib={
-                    QName(XMP_NS_RDF, 'about'): '',
-                    self._qname(key): _clean(val),
-                },
-            )
+            rdfdesc = rdf.find('rdf:Description[@rdf:about=""]', self.NS)
+            if rdfdesc is None:
+                rdfdesc = etree.SubElement(
+                    rdf,
+                    str(QName(XMP_NS_RDF, 'Description')),
+                    attrib={str(QName(XMP_NS_RDF, 'about')): ''},
+                )
+            node = etree.SubElement(rdfdesc, self._qname(key))
+            node.text = _clean(val)
         else:
             raise TypeError(f"Setting {key} to {val} with type {type(val)}") from None
 


### PR DESCRIPTION
From the [XMP specification](https://github.com/adobe/XMP-Toolkit-SDK/blob/main/docs/XMPSpecificationPart1.pdf), section 7.4:

> The RDF serialization of an XMP property shall be an XML element whose name is the name of the XMP
property. The element content shall be determined by the form of the XMP value being serialized (simple,
structure, or array), and whether the XMP value has qualifiers.

Note that this differs from the RDS spec which does allow for inline attributes.

This required no changes to the tests, which I found curious, but I am happy to add more test cases if necessary.