### PR TITLE
Use explicit page substitution in mupdf output path

### DIFF
--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -53,11 +53,10 @@ def test_draw_page(pal, monkeypatch):
         'image/png' not in mimebundle
     ), "Generated image/png when mudraw() was rigged to fail"
 
-    def return_simple_svg(prog_args, *args, **kwargs):
-        bio = BytesIO(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
-        return subprocess.CompletedProcess(prog_args, 0, stdout=bio.read(), stderr=b'')
+    def mudraw_return_svg(buffer, fmt):
+        return b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
 
-    monkeypatch.setattr(pikepdf._methods, 'run', return_simple_svg)
+    monkeypatch.setattr(pikepdf._methods, '_mudraw', mudraw_return_svg)
     mimebundle = page0._repr_mimebundle_(
         include=['image/svg+xml'], exclude=['application/pdf']
     )


### PR DESCRIPTION
Use the explicit `%d` page number substitution in mupdf output path, to avoid a bug wheras it may prepend the page number onto the directory path if it happens to contain a dot.  This approach should make mutool behavior more reliable.

While at it, replace the two `NamedTemporaryFile`s with a single `TemporaryDirectory`.  Besides being cleaner (especially that mutool now uses a different filename), it will also work correctly if mupdf starts using a temporary output file pattern rather than writing directly into the existing file.

Bug: https://bugs.ghostscript.com/show_bug.cgi?id=708653
Fixes: https://github.com/pikepdf/pikepdf/issues/660