### PR TITLE
Fixes broken "build from source" install link and add reference to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ In Production
 
 * [PDFStitcher](https://github.com/cfcurtis/sewingutils) is a utility for stitching PDF pages into a single document (i.e. N-up or page imposition).
 
+Contributing Guidelines
+-----------------------
+
+Contributions are welcome!
+
+For details, please consult the [Contributing Guidelines](https://pikepdf.readthedocs.io/en/latest/references/contributing.html).
+
 License
 -------
 


### PR DESCRIPTION
Fixes #666 

Adds the correct link to the source_build.html page so users can view the proper page.
Adds a Contribution Guidelines section so contributors can easily figure out how to properly contribute to the repo.