### PR TITLE
Specify name of missing jbig2 decoder to help users identify the solution

### DIFF
--- a/src/core/qpdf.cpp
+++ b/src/core/qpdf.cpp
@@ -612,7 +612,7 @@ void init_qpdf(py::module_ &m)
                     if (e.matches(cls_dependency_error)) {
                         python_warning(
                             "pikepdf is missing some specialized decoders "
-                            "(probably JBIG2) so not all stream contents can be "
+                            "(probably jbig2dec) so not all stream contents can be "
                             "tested.");
                         w.setDecodeLevel(qpdf_dl_generalized);
                         w.write();


### PR DESCRIPTION
It took me some time to figure out why this warning was appearing even when jbig2 was clearly installed on my system. This change will make it clearer that it is jbig2dec rather than jbig2 that needs to be installed.