### PR TITLE
Support reduced precision dates (YYYY, YYYY-MM) in XMP/DocumentInfo conversion

### DIFF
--- a/src/pikepdf/models/metadata.py
+++ b/src/pikepdf/models/metadata.py
@@ -275,17 +275,23 @@ class DateConverter(Converter):
     @staticmethod
     def xmp_from_docinfo(docinfo_val):
         """Derive XMP date from DocumentInfo."""
+        if isinstance(docinfo_val, String):
+            docinfo_val = str(docinfo_val)
         if docinfo_val == '':
             return ''
+        val = docinfo_val[2:] if docinfo_val.startswith('D:') else docinfo_val
+        if len(val) in (4, 6) and val.isdigit():
+            return val if len(val) == 4 else f'{val[:4]}-{val[4:]}'
         return decode_pdf_date(docinfo_val).isoformat()
 
     @staticmethod
     def docinfo_from_xmp(xmp_val):
         """Derive DocumentInfo from XMP."""
+        if len(xmp_val) in (4, 7) and 'T' not in xmp_val:
+            return f'D:{xmp_val.replace("-", "")}'
         if xmp_val.endswith('Z'):
             xmp_val = xmp_val[:-1] + '+00:00'
-        dateobj = datetime.fromisoformat(xmp_val)
-        return encode_pdf_date(dateobj)
+        return encode_pdf_date(datetime.fromisoformat(xmp_val))
 
 
 class DocinfoMapping(NamedTuple):


### PR DESCRIPTION
## Summary
- Fixes `docinfo_from_xmp()` raising ValueError when given reduced precision dates (YYYY or YYYY-MM format)
- `datetime.fromisoformat()` doesn't support these formats, but both PDF pdfmark spec and XMP spec allow them
- Detects reduced precision dates by length and absence of 'T', then converts directly without datetime parsing

## Test plan
- [x] Added unit tests for `docinfo_from_xmp()` with reduced precision dates
- [x] Added unit tests for `xmp_from_docinfo()` with reduced precision dates  
- [x] Added roundtrip test to verify YYYY and YYYY-MM preserve precision
- [x] Added integration tests with actual PDF metadata
- [x] All 87 tests in test_metadata.py pass

Attempts to fix #576