### PR TITLE
fix: allow None in Array.append (nanobind .none() annotation) (issue #725)

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -1359,7 +1359,8 @@ void init_object(py::module_ &m)
                 QpdfLockGuard lock(h.getOwningQPDF());
                 auto item = objecthandle_encode(pyitem);
                 return h.appendItem(item);
-            })
+            },
+            py::arg("pyitem").none())
         .def("extend",
             [](QPDFObjectHandle &h, py::iterable iter) {
                 QpdfLockGuard lock(h.getOwningQPDF());


### PR DESCRIPTION
## Summary

Fix `Array.append(None)` regression introduced in v10.6+ after the nanobind migration.

## Problem

`pikepdf.Array.append(None)` raises `TypeError` since v10.6:
```
TypeError: append(): incompatible function arguments. The following argument types are supported:
    1. append(self, arg: object, /) -> None
Invoked with types: pikepdf.objects.Object, NoneType
```

This worked in v10.5 (pybind11 era) where `py::object` parameters implicitly accepted `None`.

## Root Cause

nanobind requires explicit `.none()` annotation on `py::object` parameters to accept `None` values. The `append` method's `py::object pyitem` parameter was missing this annotation. The underlying C++ function `objecthandle_encode()` already correctly handles `None` by converting it to `QPDFObjectHandle::newNull()`, so only the type annotation is missing.

## Fix

Added `py::arg("pyitem").none()` to the `append` method definition, matching the pattern already used by `set_ob`, `__setitem__`, and other methods in the same file.

## Testing

The existing test suite covers Array operations. After this fix, `arr.append(None)` will produce a PDF null object in the array, matching the v10.5 behavior and the documented behavior of `objecthandle_encode(None) -> newNull()`.