### PR TITLE
fix: validate encryption parameter type in Pdf.save() to prevent segfault (issue #727)

### DIFF
--- a/src/pikepdf/_methods.py
+++ b/src/pikepdf/_methods.py
@@ -452,6 +452,11 @@ class Extend_Pdf:
         recompress_flate: bool = False,
         deterministic_id: bool = False,
     ) -> None:
+        if encryption is not None and not isinstance(encryption, (bool, Encryption, dict, tuple)):
+            raise TypeError(
+                f"encryption must be an Encryption, dict, bool, or None, "
+                f"not {type(encryption).__name__}"
+            )
         if not filename_or_stream and getattr(self, '_original_filename', None):
             filename_or_stream = self._original_filename
         if not filename_or_stream:


### PR DESCRIPTION
## Summary

Add Python-level type validation for the `encryption` parameter in `Pdf.save()` to raise `TypeError` instead of segfaulting when an invalid object (e.g., `MagicMock`, `list`) is passed.

## Problem

Passing a mock/invalid object (e.g., `MagicMock()`, `[]`) to the `encryption` argument in `Pdf.save()` causes a segmentation fault. The C++ binding at `setup_encryption()` (qpdf.cpp:195) assumes the object is a dict or tuple without type checking, leading to an unsafe `py::borrow<py::dict>()` cast.

```python
pdf.save("out.pdf", encryption=MagicMock())  # Segfault
pdf.save("out.pdf", encryption=[])            # Segfault
```

## Fix

Add a type guard at the start of `Pdf.save()` that validates `encryption` is one of the accepted types (`Encryption`, `dict`, `bool`, or `None`). Invalid types now raise a clear `TypeError`:

```python
if encryption is not None and not isinstance(encryption, (bool, Encryption, dict, tuple)):
    raise TypeError(
        f"encryption must be an Encryption, dict, bool, or None, "
        f"not {type(encryption).__name__}"
    )
```

This prevents the segfault by catching invalid input before it reaches the C++ layer.

## Files Changed

- `src/pikepdf/_methods.py` — Added type validation in `Pdf.save()`

## Why Python-level and not C++?

The C++ fix (`setup_encryption` in qpdf.cpp) would also work but requires recompiling the extension module. The Python-level fix is:
- Equally effective (prevents invalid objects from reaching C++)
- No build dependency changes
- Consistent with existing Python-level validation patterns in the same method (e.g., `filename_or_stream` type checks)