### PR TITLE
fix: validate sub-byte image data length before allocating unpack buffer

### DIFF
--- a/docs/releasenotes/version10.md
+++ b/docs/releasenotes/version10.md
@@ -91,6 +91,16 @@ the architecture notes on thread safety.
     {exc}`pikepdf.DecompressionBombError` and borderline images emit
     {exc}`pikepdf.DecompressionBombWarning` (both subclass Pillow's equivalents).
     (#733)
+-   Sub-byte (2-bit and 4-bit) image extraction now verifies that the image
+    stream holds enough data for the declared ``/Width`` and ``/Height`` before
+    allocating its unpack buffer, raising
+    {exc}`~pikepdf.exceptions.ImageDecompressionError` when it does not. This
+    bounds the allocation by the data actually present, so a large declared size
+    backed by a few stream bytes can no longer exhaust memory even below the
+    {attr}`pikepdf.PdfImage.MAX_IMAGE_PIXELS` budget or when that limit is
+    disabled. The unpack buffer is also no longer over-allocated by a factor of
+    the packing ratio, reducing peak memory for 2-bit and 4-bit images by 4x and
+    2x respectively.
 
 ### Fixed
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -184,6 +184,16 @@ pikepdf.PdfImage.MAX_IMAGE_PIXELS = None
 Because pikepdf's exception types subclass Pillow's, code that already handles
 `PIL.Image.DecompressionBombError` will catch pikepdf's too.
 
+The pixel limit bounds how large an image pikepdf will decode, but it says
+nothing about whether the declared size is *consistent* with the stream. As a
+second line of defence, extraction of 2-bit and 4-bit images checks that the
+stream holds enough data for the declared `/Width` and `/Height` before it
+allocates, and raises
+{class}`~pikepdf.exceptions.ImageDecompressionError` when it does not. That
+check applies regardless of `MAX_IMAGE_PIXELS`, so an image that declares
+millions of pixels but stores a handful of bytes is rejected cheaply rather than
+extracted as a mostly-black picture.
+
 ## Stored bytes are not the presentation image
 
 The raw bytes stored in an image stream are not, on their own, the picture a

--- a/src/pikepdf/models/_transcoding.py
+++ b/src/pikepdf/models/_transcoding.py
@@ -48,11 +48,36 @@ def unpack_subbyte_pixels(
         0b11 = 1.00 = 0xff
     When scale is 1, no scaling is applied, appropriate when
     the bytes are palette indexes.
+
+    Raises:
+        ImageDecompressionError: if *size* is not positive, or *packed* is
+            shorter than a *size* image at *bits* per component requires.
     """
     width, height = size
+    if width <= 0 or height <= 0:
+        raise ImageDecompressionError(f"Image has invalid dimensions {width}x{height}")
     bits_per_byte = 8 // bits
     stride = _next_multiple(width, bits_per_byte)
-    buffer = bytearray(bits_per_byte * stride * height)
+
+    # Each row of image data begins on a byte boundary (ISO 32000-2 §8.9.3),
+    # so a row occupies ceil(width * bits / 8) packed bytes. Requiring that many
+    # bytes per row *before* allocating bounds the allocation by the data
+    # actually present: width and height are attacker-controlled /Width and
+    # /Height, and a crafted PDF can declare an enormous image backed by a
+    # handful of stream bytes, exhausting memory (a DoS). The pixel limit in
+    # PdfImage.MAX_IMAGE_PIXELS caps plausible images; this catches the
+    # implausible ones, and applies even when that limit is disabled.
+    packed_row_bytes = (width * bits + 7) // 8
+    expected = packed_row_bytes * height
+    if len(packed) < expected:
+        raise ImageDecompressionError(
+            f"Image data is {len(packed)} bytes, but a {width}x{height} image "
+            f"at {bits} bits per component requires {expected} bytes"
+        )
+
+    # Unpacking produces one byte per pixel, with each row padded out to
+    # *stride* bytes, so bits_per_byte * packed_row_bytes == stride.
+    buffer = bytearray(stride * height)
     max_read = len(buffer) // bits_per_byte
     if scale == 0:
         # 255 // (2**bits - 1) is exact for bits in {1, 2, 4, 8}:

--- a/tests/test_image_access.py
+++ b/tests/test_image_access.py
@@ -37,6 +37,7 @@ from pikepdf import (
 )
 from pikepdf.models._transcoding import _next_multiple, unpack_subbyte_pixels
 from pikepdf.models.image import (
+    ImageDecompressionError,
     PdfJpxImage,
     UnsupportedImageTypeError,
 )
@@ -1855,6 +1856,72 @@ def test_direct_path_honors_pikepdf_limit(congress, restore_pixel_limits):
     xobj, _ = congress
     with pytest.raises(pikepdf.DecompressionBombError):
         PdfImage(xobj).as_pil_image()
+
+
+# --- Sub-byte unpacking of truncated image data ---------------------------
+
+
+@pytest.mark.parametrize('bits', [2, 4])
+def test_unpack_subbyte_rejects_truncated_data(bits):
+    # The unpack buffer is sized from the declared /Width and /Height, so the
+    # declared size must be backed by enough data before anything is allocated.
+    with pytest.raises(ImageDecompressionError, match='requires'):
+        unpack_subbyte_pixels(b'\x00', (200000, 200000), bits)
+
+
+@pytest.mark.parametrize('bits', [2, 4])
+@pytest.mark.parametrize('width,height', [(1, 1), (5, 3), (16, 16)])
+def test_unpack_subbyte_accepts_exact_data(bits, width, height):
+    packed_row_bytes = ceil(width * bits / 8)
+    buffer, stride = unpack_subbyte_pixels(
+        b'\x00' * (packed_row_bytes * height), (width, height), bits
+    )
+    assert stride == _next_multiple(width, 8 // bits)
+    # One byte per pixel, each row padded out to stride.
+    assert len(buffer) == stride * height
+
+
+@pytest.mark.parametrize('size', [(0, 1), (1, 0), (-1, 1)])
+def test_unpack_subbyte_rejects_nonpositive_size(size):
+    with pytest.raises(ImageDecompressionError, match='invalid dimensions'):
+        unpack_subbyte_pixels(b'\x00', size, 4)
+
+
+def test_truncated_4bit_image_raises_under_pixel_limit(restore_pixel_limits):
+    # 64x64 is only 4096 pixels, far below MAX_IMAGE_PIXELS, so the bomb check
+    # passes -- but one byte of data cannot fill it.
+    pdf = pikepdf.new()
+    img = PdfImage(
+        _image_stream(
+            pdf,
+            bpc=4,
+            colorspace=Name.DeviceGray,
+            width=64,
+            height=64,
+            imbytes=b'\x00',
+        )
+    )
+    with pytest.raises(ImageDecompressionError):
+        img.as_pil_image()
+
+
+def test_truncated_4bit_image_raises_with_pixel_limit_disabled(restore_pixel_limits):
+    # With the bomb guard disabled, the length check is the only thing standing
+    # between a 796-byte PDF and an 80 GB allocation.
+    PdfImage.MAX_IMAGE_PIXELS = None
+    pdf = pikepdf.new()
+    img = PdfImage(
+        _image_stream(
+            pdf,
+            bpc=4,
+            colorspace=Name.DeviceGray,
+            width=200000,
+            height=200000,
+            imbytes=b'\x00',
+        )
+    )
+    with pytest.raises(ImageDecompressionError):
+        img.as_pil_image()
 
 
 # --- Gap A: CalRGB / CalGray / CalCMYK colour spaces -----------------------


### PR DESCRIPTION
`MAX_IMAGE_PIXELS` (#733) caps how large an image pikepdf will decode, but nothing
relates the declared size to the data actually present. Two cases remain in the
2/4-bit path:

- A 4-bit image declaring 12000x12000 is 1.4e8 pixels — well under the 500M default
  budget — yet allocates 289 MB from a single byte of stream data. At the budget
  boundary that is ~2 GB.
- `MAX_IMAGE_PIXELS = None` is documented and supported; with it, the full unbounded
  allocation is back (~80 GB for a 200000x200000 4-bit image).

```python
import pikepdf
from pikepdf import Dictionary, Name, Stream
from pikepdf.models.image import PdfImage

pdf = pikepdf.new()
img = Stream(pdf, b"\x00", Dictionary(
    Type=Name.XObject, Subtype=Name.Image, Width=12000, Height=12000,
    BitsPerComponent=4, ColorSpace=Name.DeviceGray))
PdfImage(img).as_pil_image()  # before: 289 MB allocated; after: ImageDecompressionError
```

`unpack_subbyte_pixels()` now requires `ceil(width * bits / 8)` bytes per row (rows
begin on a byte boundary, ISO 32000-2 §8.9.3) before allocating, and raises
`ImageDecompressionError` otherwise. Non-positive dimensions are rejected the same
way. The allocation is then bounded by the data actually supplied, independent of
`MAX_IMAGE_PIXELS`.

Separately: the buffer was over-allocated by the packing ratio.
`bits_per_byte * stride * height`, where unpacking emits one byte per pixel with rows
padded to `stride` — so `stride * height` is exact, and the old expression was 4x over
for 2-bit and 2x for 4-bit. `max_read` sliced correspondingly more input than an image
needs. Both now line up exactly.

### Behavior change

A 2/4-bit image whose stream is short previously extracted with a black tail; it now
raises. That is arguably more correct — the tail was never real image data — but it
cuts against 745b92f6 ("Try harder to extract corrupt images and warn when they
occur"). Happy to soften this to a warning plus a clamped allocation if you would
rather preserve partial extraction; the length check is what bounds the allocation
either way.

### Testing

`uv run pytest`: 1345 passed, 11 skipped, 1 xfailed, 1 xpassed. Added 13 tests covering
truncated / exact-length / non-positive-size unpack, and end-to-end `as_pil_image` for
both the under-budget and `MAX_IMAGE_PIXELS = None` paths. Release note added under
`### Security` in `docs/releasenotes/version10.md`, plus a paragraph in
`docs/topics/images.md`.
