### PR TITLE
fix: raise DataDecodingError when JBIG2 decode fails

### DIFF
--- a/docs/releasenotes/version10.md
+++ b/docs/releasenotes/version10.md
@@ -17,9 +17,19 @@ the architecture notes on thread safety.
 ## v10.11.1
 
 - A JBIG2 decode failure (jbig2dec present but the payload is invalid) now
-  raises {exc}`~pikepdf.exceptions.DataDecodingError` with the decoder error,
-  instead of a bare ``RuntimeError("qpdf will consume this exception")`` plus
-  an unraisable traceback on stderr. (#735)
+  raises {exc}`~pikepdf.exceptions.DataDecodingError` with the decoder's error
+  message, instead of a bare `RuntimeError("qpdf will consume this exception")`
+  plus an unraisable traceback on stderr. (#735)
+- Exceptions other than {exc}`~pikepdf.exceptions.DataDecodingError` raised by
+  a JBIG2 decoder now keep their own type. Previously a failure unrelated to
+  the image data -- a {exc}`~pikepdf.exceptions.DependencyError` from a custom
+  decoder, or `KeyboardInterrupt` -- was reported as if the JBIG2 data were
+  corrupt. Implementations of
+  {class}`pikepdf.jbig2.JBIG2DecoderInterface.decode_jbig2` should raise
+  `DataDecodingError` to report undecodable data.
+- When the JBIG2 image comes from a file on disk, qpdf traps the decoder's
+  exception and records it as a warning, so the decoder's message is available
+  from {meth}`pikepdf.Pdf.get_warnings` rather than in the exception.
 
 ## v10.11.0
 

--- a/docs/releasenotes/version10.md
+++ b/docs/releasenotes/version10.md
@@ -14,6 +14,13 @@ free-threaded use required building from source. As always, coordinating
 concurrent modification of the same object across threads requires a lock -- see
 the architecture notes on thread safety.
 
+## v10.11.1
+
+- A JBIG2 decode failure (jbig2dec present but the payload is invalid) now
+  raises {exc}`~pikepdf.exceptions.DataDecodingError` with the decoder error,
+  instead of a bare ``RuntimeError("qpdf will consume this exception")`` plus
+  an unraisable traceback on stderr. (#735)
+
 ## v10.11.0
 
 - Extended PDF outline (bookmark) support to cover more of the spec:

--- a/src/core/jbig2-inl.h
+++ b/src/core/jbig2-inl.h
@@ -48,15 +48,28 @@ public:
             extracted_obj = extract_jbig2(pydata,
                 py::bytes(this->jbig2globals.data(), this->jbig2globals.size()));
         } catch (py::python_error &e) {
-            // qpdf may trap exceptions thrown during Pipeline::finish() and
-            // convert them to a generic "not decodable" error. A runtime_error
-            // whose message matches is_data_decoding_error() is translated to
-            // pikepdf.DataDecodingError. In practice this exception often
-            // escapes to the caller (#735) rather than being consumed; do not
-            // write the Python error as unraisable (that leaked a traceback
-            // and left a bare RuntimeError whose text was an implementation
-            // note).
-            throw std::runtime_error(std::string("Pl_JBIG2: ") + e.what());
+            // We are called from Pipeline::finish(). If the stream data came
+            // from a file, qpdf traps everything thrown here, downgrades it to
+            // a warning and reports "unfilterable stream"; if the data was set
+            // from memory, whatever we throw reaches the caller. Either way a
+            // Python exception cannot cross qpdf's C++ frames intact, so a
+            // decode failure is re-thrown tagged with the sentinel prefix that
+            // is_data_decoding_error() recognizes, and the exception translator
+            // turns it back into pikepdf.DataDecodingError. See pikepdf.h.
+            //
+            // Only DataDecodingError is smuggled out this way. Anything else --
+            // DependencyError from a custom decoder, KeyboardInterrupt, a bug in
+            // the decoder -- keeps its own type and traceback, because relabeling
+            // it would blame corrupt JBIG2 data for an unrelated failure. Those
+            // exceptions propagate as py::python_error, which nanobind restores
+            // if qpdf does not trap it first.
+            if (!e.matches(py::handle(get_data_decoding_error_type())))
+                throw;
+            // Use str(exception), not e.what(): the latter is a formatted
+            // traceback, which would end up embedded in the message the user
+            // sees.
+            throw std::runtime_error(std::string(JBIG2_DECODE_ERROR_PREFIX) + " " +
+                                     py::str(e.value()).c_str());
         }
 
         return to_string(extracted_obj);

--- a/src/core/jbig2-inl.h
+++ b/src/core/jbig2-inl.h
@@ -48,15 +48,15 @@ public:
             extracted_obj = extract_jbig2(pydata,
                 py::bytes(this->jbig2globals.data(), this->jbig2globals.size()));
         } catch (py::python_error &e) {
-            // In qpdf over here...
-            // https://github.com/qpdf/qpdf/blob/dd3b2cedd3164692925df1ef7414eb452343372f/libqpdf/QPDF.cc#L2955-2984
-            // all exceptions that happen during Pipeline::finish() will be trapped
-            // and converted into a generic error about the object being not decodable.
-            // As a consequence we get a Python exception through C++, so we discard it
-            // as unraisable so that at least the user gets a chance to see it.
-            e.restore();
-            PyErr_WriteUnraisable(nullptr);
-            throw std::runtime_error("qpdf will consume this exception");
+            // qpdf may trap exceptions thrown during Pipeline::finish() and
+            // convert them to a generic "not decodable" error. A runtime_error
+            // whose message matches is_data_decoding_error() is translated to
+            // pikepdf.DataDecodingError. In practice this exception often
+            // escapes to the caller (#735) rather than being consumed; do not
+            // write the Python error as unraisable (that leaked a traceback
+            // and left a bare RuntimeError whose text was an implementation
+            // note).
+            throw std::runtime_error(std::string("Pl_JBIG2: ") + e.what());
         }
 
         return to_string(extracted_obj);

--- a/src/core/pikepdf.cpp
+++ b/src/core/pikepdf.cpp
@@ -132,6 +132,7 @@ bool is_data_decoding_error(const std::runtime_error &e)
         "|Pl_LZWDecoder:"
         "|Pl_Flate:"
         "|Pl_DCT:"
+        "|Pl_JBIG2:"
         "|stream inflate:",
         std::regex_constants::icase);
 

--- a/src/core/pikepdf.cpp
+++ b/src/core/pikepdf.cpp
@@ -50,6 +50,11 @@ static constinit std::atomic<PyObject *> exc_referencecycle{nullptr};
 // explicit mode takes precedence over the global EXPLICIT_CONVERSION_MODE.
 static thread_local int thread_explicit_depth = 0;
 
+PyObject *get_data_decoding_error_type()
+{
+    return exc_datadecoding.load(std::memory_order_acquire);
+}
+
 uint get_decimal_precision()
 {
     return DECIMAL_PRECISION.load();
@@ -124,16 +129,19 @@ auto translate_qpdf_logic_error(const std::exception &e)
 
 bool is_data_decoding_error(const std::runtime_error &e)
 {
+    // JBIG2_DECODE_ERROR_PREFIX is pikepdf's own contribution to this list; see
+    // pikepdf.h for why Pl_JBIG2 tags its errors with it.
     static const std::regex decoding_error_pattern(
-        "character out of range"
-        "|broken end-of-data sequence in base 85 data"
-        "|unexpected z during base 85 decode"
-        "|TIFFPredictor created with"
-        "|Pl_LZWDecoder:"
-        "|Pl_Flate:"
-        "|Pl_DCT:"
-        "|Pl_JBIG2:"
-        "|stream inflate:",
+        std::string("character out of range"
+                    "|broken end-of-data sequence in base 85 data"
+                    "|unexpected z during base 85 decode"
+                    "|TIFFPredictor created with"
+                    "|Pl_LZWDecoder:"
+                    "|Pl_Flate:"
+                    "|Pl_DCT:"
+                    "|stream inflate:"
+                    "|") +
+            JBIG2_DECODE_ERROR_PREFIX,
         std::regex_constants::icase);
 
     return std::regex_search(e.what(), decoding_error_pattern);

--- a/src/core/pikepdf.h
+++ b/src/core/pikepdf.h
@@ -52,6 +52,23 @@ py::object decimal_from_pdfobject(QPDFObjectHandle h);
 // From pikepdf.cpp - forward declaration for type_caster
 bool get_explicit_conversion_mode();
 
+// Sentinel prefix that carries a JBIG2 decode failure across qpdf's C++ frames.
+//
+// A Python exception raised by the JBIG2 decoder cannot travel through libqpdf,
+// which only understands std::exception. Pl_JBIG2 (jbig2-inl.h) therefore
+// re-throws the failure as a std::runtime_error whose message begins with this
+// prefix, and is_data_decoding_error() (pikepdf.cpp) matches the prefix so the
+// exception translator turns it back into pikepdf.DataDecodingError. The same
+// convention is what libqpdf itself uses for "Pl_Flate:", "Pl_DCT:", etc., so
+// pikepdf's own pipeline reports errors the way qpdf's pipelines do.
+//
+// Both ends of this contract live in C++; nothing in the Python layer should
+// match on the prefix.
+inline constexpr const char *JBIG2_DECODE_ERROR_PREFIX = "Pl_JBIG2:";
+
+// From pikepdf.cpp - the pikepdf.DataDecodingError class object (borrowed).
+PyObject *get_data_decoding_error_type();
+
 namespace nanobind {
 namespace detail {
 template <>

--- a/src/pikepdf/jbig2.py
+++ b/src/pikepdf/jbig2.py
@@ -38,7 +38,14 @@ class JBIG2DecoderInterface(ABC):
 
     @abstractmethod
     def decode_jbig2(self, jbig2: bytes, jbig2_globals: bytes) -> bytes:
-        """Decode JBIG2 from jbig2 and globals, returning decoded bytes."""
+        """Decode JBIG2 from jbig2 and globals, returning decoded bytes.
+
+        Raise :class:`pikepdf.DataDecodingError` if the data cannot be decoded.
+        That is the only exception pikepdf's C++ pipeline can carry across
+        libqpdf's frames with its type intact; any other exception is reported
+        as-is when possible, and otherwise reaches the caller as a generic qpdf
+        "unfilterable stream" error.
+        """
 
     def available(self) -> bool:
         """Return True if decoder is available."""

--- a/src/pikepdf/jbig2.py
+++ b/src/pikepdf/jbig2.py
@@ -18,6 +18,7 @@ from tempfile import TemporaryDirectory
 
 from packaging.version import InvalidVersion, Version
 
+from pikepdf._core import DataDecodingError
 from pikepdf._exceptions import DependencyError
 
 if sys.platform == 'win32':
@@ -91,9 +92,28 @@ class JBIG2Decoder(JBIG2DecoderInterface):
 
             args.append(os.fspath(image_path))
 
-            self._run(
-                args, stdout=DEVNULL, check=True, creationflags=self._creationflags
-            )
+            try:
+                self._run(
+                    args,
+                    stdout=DEVNULL,
+                    stderr=PIPE,
+                    check=True,
+                    creationflags=self._creationflags,
+                )
+            except FileNotFoundError as e:
+                raise DependencyError("jbig2dec - not installed or not found") from e
+            except CalledProcessError as e:
+                detail = e.stderr
+                if isinstance(detail, bytes):
+                    detail = detail.decode("utf-8", errors="replace")
+                detail = (detail or "").strip()
+                msg = (
+                    "jbig2dec failed to decode JBIG2 image data"
+                    f" (exit status {e.returncode})"
+                )
+                if detail:
+                    msg = f"{msg}: {detail}"
+                raise DataDecodingError(msg) from e
             from PIL import Image
 
             with Image.open(output_path) as im:

--- a/src/pikepdf/models/image/_extract.py
+++ b/src/pikepdf/models/image/_extract.py
@@ -260,23 +260,29 @@ def _transcoded_1bit(pim: PdfImage) -> Image.Image:
         raise UnsupportedImageTypeError("1-bit RGB and CMYK are not supported")
     try:
         data = pim.read_bytes()
-    except DataDecodingError:
-        raise
     except (RuntimeError, PdfError) as e:
-        msg = str(e)
-        if 'Pl_JBIG2:' in msg:
-            raise DataDecodingError(msg) from e
-        if 'read_bytes called on unfilterable stream' in msg:
-            if not jbig2.get_decoder().available():
-                raise DependencyError(
-                    "jbig2dec - not installed or installed version is too old "
-                    "(older than version 0.15)"
-                ) from None
-            # Decoder is present; qpdf swallowed the JBIG2 pipeline error.
-            raise DataDecodingError(
-                "jbig2dec failed to decode JBIG2 image data"
-            ) from e
-        raise
+        # qpdf says "unfilterable stream" for any filter it could not apply, so
+        # only blame JBIG2 when JBIG2Decode is actually one of them. Today the
+        # other terminal codecs are handled by extract_direct before they reach
+        # here, but the guard keeps a future one from being reported as a
+        # jbig2dec failure.
+        if (
+            'read_bytes called on unfilterable stream' not in str(e)
+            or '/JBIG2Decode' not in pim.filters
+        ):
+            raise
+        if not jbig2.get_decoder().available():
+            raise DependencyError(
+                "jbig2dec - not installed or installed version is too old "
+                "(older than version 0.15)"
+            ) from None
+        # The decoder is present and failed. qpdf trapped the decoder's
+        # exception inside Pipeline::finish() and downgraded it to a warning on
+        # the owning Pdf, so the decoder's own message is not available here.
+        raise DataDecodingError(
+            "jbig2dec failed to decode JBIG2 image data; the decoder's message "
+            "is reported as a warning on the Pdf (see Pdf.get_warnings())"
+        ) from e
 
     # Pillow's '1' mode stores a byte per pixel, and Image.frombytes allocates
     # the whole image before it discovers the data is short -- so, as in

--- a/src/pikepdf/models/image/_extract.py
+++ b/src/pikepdf/models/image/_extract.py
@@ -23,7 +23,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, BinaryIO, cast
 
 from pikepdf import jbig2
-from pikepdf._core import Pdf, PdfError, StreamDecodeLevel
+from pikepdf._core import DataDecodingError, Pdf, PdfError, StreamDecodeLevel
 from pikepdf._exceptions import DependencyError
 from pikepdf.models import _transcoding
 from pikepdf.models._image_exceptions import (
@@ -260,15 +260,22 @@ def _transcoded_1bit(pim: PdfImage) -> Image.Image:
         raise UnsupportedImageTypeError("1-bit RGB and CMYK are not supported")
     try:
         data = pim.read_bytes()
+    except DataDecodingError:
+        raise
     except (RuntimeError, PdfError) as e:
-        if (
-            'read_bytes called on unfilterable stream' in str(e)
-            and not jbig2.get_decoder().available()
-        ):
-            raise DependencyError(
-                "jbig2dec - not installed or installed version is too old "
-                "(older than version 0.15)"
-            ) from None
+        msg = str(e)
+        if 'Pl_JBIG2:' in msg:
+            raise DataDecodingError(msg) from e
+        if 'read_bytes called on unfilterable stream' in msg:
+            if not jbig2.get_decoder().available():
+                raise DependencyError(
+                    "jbig2dec - not installed or installed version is too old "
+                    "(older than version 0.15)"
+                ) from None
+            # Decoder is present; qpdf swallowed the JBIG2 pipeline error.
+            raise DataDecodingError(
+                "jbig2dec failed to decode JBIG2 image data"
+            ) from e
         raise
 
     # Pillow's '1' mode stores a byte per pixel, and Image.frombytes allocates

--- a/tests/test_jbig2.py
+++ b/tests/test_jbig2.py
@@ -211,14 +211,83 @@ def test_decode_jbig2_wraps_called_process_error(patch_jbig2dec: Callable[..., N
     assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
 
-@needs_jbig2dec
-def test_jbig2_invalid_payload_is_data_decoding_error():
-    """Owner repro from #735: invalid JBIG2 data must not leak RuntimeError."""
-    pdf = Pdf.new()
+def invalid_jbig2_image(pdf: Pdf) -> pikepdf.Stream:
+    """Build the in-memory JBIG2 image from the #735 report.
+
+    A stream whose data was set from memory (rather than read from a file) is
+    the case where qpdf does *not* trap what Pl_JBIG2 throws during
+    Pipeline::finish(), so whatever the decoder raised reaches the caller.
+    """
     st = pdf.make_stream(b'\x00' * 50)
     st.Type, st.Subtype = Name.XObject, Name.Image
     st.Width, st.Height, st.BitsPerComponent = 20, 20, 1
     st.ColorSpace = Name.DeviceGray
     st.Filter = pikepdf.Array([Name.JBIG2Decode])
-    with pytest.raises(DataDecodingError):
-        PdfImage(st).as_pil_image()
+    return st
+
+
+@needs_jbig2dec
+def test_jbig2_invalid_payload_is_data_decoding_error():
+    """Owner repro from #735: invalid JBIG2 data must not leak RuntimeError."""
+    pdf = Pdf.new()
+    with pytest.raises(DataDecodingError) as excinfo:
+        PdfImage(invalid_jbig2_image(pdf)).as_pil_image()
+
+    # The message must be jbig2dec's complaint, not a Python traceback smuggled
+    # through as text (which is what python_error::what() would have given us).
+    msg = str(excinfo.value)
+    assert 'jbig2dec' in msg
+    assert 'Traceback' not in msg
+
+
+class _RaisingDecoder(pikepdf.jbig2.JBIG2DecoderInterface):
+    """A decoder that is available but fails with a caller-chosen exception."""
+
+    def __init__(self, exc: BaseException):
+        self.exc = exc
+
+    def check_available(self) -> None:
+        return None
+
+    def decode_jbig2(self, jbig2: bytes, jbig2_globals: bytes) -> bytes:
+        raise self.exc
+
+
+@pytest.fixture
+def raising_decoder():
+    original = pikepdf.jbig2.get_decoder()
+
+    def _set(exc: BaseException):
+        pikepdf.jbig2.set_decoder(_RaisingDecoder(exc))
+
+    yield _set
+    pikepdf.jbig2.set_decoder(original)
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [
+        DependencyError("my decoder went missing"),
+        KeyboardInterrupt(),
+        ValueError("decoder bug"),
+    ],
+    ids=['dependency', 'keyboard-interrupt', 'decoder-bug'],
+)
+def test_jbig2_non_decoding_errors_keep_their_type(raising_decoder, exc):
+    """Only DataDecodingError is relabeled on its way out of Pl_JBIG2.
+
+    Everything else keeps its own type, so an unrelated failure is not reported
+    as corrupt JBIG2 data. See JBIG2_DECODE_ERROR_PREFIX in src/core/pikepdf.h.
+    """
+    raising_decoder(exc)
+    pdf = Pdf.new()
+    with pytest.raises(type(exc)) as excinfo:
+        PdfImage(invalid_jbig2_image(pdf)).as_pil_image()
+    assert excinfo.value is exc
+
+
+def test_jbig2_decoding_error_is_relabeled(raising_decoder):
+    raising_decoder(DataDecodingError("decoder said no"))
+    pdf = Pdf.new()
+    with pytest.raises(DataDecodingError, match="decoder said no"):
+        PdfImage(invalid_jbig2_image(pdf)).as_pil_image()

--- a/tests/test_jbig2.py
+++ b/tests/test_jbig2.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from collections.abc import Callable
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -14,11 +12,11 @@ import pytest
 
 import pikepdf
 from pikepdf import (
+    DataDecodingError,
     DependencyError,
     Name,
     Object,
     Pdf,
-    PdfError,
     PdfImage,
 )
 from pikepdf.jbig2 import JBIG2Decoder
@@ -46,27 +44,6 @@ def first_image_in(resources, request):
 @pytest.fixture
 def jbig2(first_image_in):
     return first_image_in('jbig2.pdf')
-
-
-@contextmanager
-def expect_unraisable_exception():
-    """Assert that an unraisable exception occurs, suppressing pytest's warning.
-
-    pytest defers PytestUnraisableExceptionWarning until after the test body,
-    so pytest.warns() cannot capture it. We intercept sys.unraisablehook directly.
-    """
-    captured = []
-    old_hook = sys.unraisablehook
-
-    def hook(unraisable):
-        captured.append(unraisable)
-
-    sys.unraisablehook = hook
-    try:
-        yield
-    finally:
-        sys.unraisablehook = old_hook
-    assert captured, "Expected an unraisable exception but none occurred"
 
 
 @pytest.fixture
@@ -183,9 +160,8 @@ def test_jbig2_error(first_image_in, patch_jbig2dec: Callable[..., None]):
     patch_jbig2dec(run_claim_broken)
 
     pim = PdfImage(xobj)
-    with expect_unraisable_exception():
-        with pytest.raises(PdfError, match="unfilterable stream"):
-            pim.as_pil_image()
+    with pytest.raises(DataDecodingError, match="jbig2dec failed to decode"):
+        pim.as_pil_image()
 
 
 def test_jbig2_too_old(first_image_in, patch_jbig2dec: Callable[..., None]):
@@ -216,9 +192,33 @@ def test_jbig2_reports_no_version(first_image_in, patch_jbig2dec: Callable[..., 
 
     patch_jbig2dec(run_claim_no_version)
 
-    # Our patch to jbig2dec only provides a blank version string, or returns an error.
-    # So we expect a PdfError here (and not an InvalidVersion or DependencyError).
+    # Blank version is treated as unknown-but-present; decode then fails.
     pim = PdfImage(xobj)
-    with expect_unraisable_exception():
-        with pytest.raises(PdfError, match='read_bytes called on unfilterable stream'):
-            pim.as_pil_image()
+    with pytest.raises(DataDecodingError, match="jbig2dec failed to decode"):
+        pim.as_pil_image()
+
+
+def test_decode_jbig2_wraps_called_process_error(patch_jbig2dec: Callable[..., None]):
+    def run_claim_broken(args, *pargs, **kwargs):
+        if args[1] == '--version':
+            return subprocess.CompletedProcess(args, 0, stdout='0.15', stderr='')
+        raise subprocess.CalledProcessError(1, 'jbig2dec', stderr=b'segment too short')
+
+    patch_jbig2dec(run_claim_broken)
+    decoder = pikepdf.jbig2.get_decoder()
+    with pytest.raises(DataDecodingError, match="segment too short") as excinfo:
+        decoder.decode_jbig2(b'\x00' * 20, b'')
+    assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+
+
+@needs_jbig2dec
+def test_jbig2_invalid_payload_is_data_decoding_error():
+    """Owner repro from #735: invalid JBIG2 data must not leak RuntimeError."""
+    pdf = Pdf.new()
+    st = pdf.make_stream(b'\x00' * 50)
+    st.Type, st.Subtype = Name.XObject, Name.Image
+    st.Width, st.Height, st.BitsPerComponent = 20, 20, 1
+    st.ColorSpace = Name.DeviceGray
+    st.Filter = pikepdf.Array([Name.JBIG2Decode])
+    with pytest.raises(DataDecodingError):
+        PdfImage(st).as_pil_image()


### PR DESCRIPTION
## Summary

When `jbig2dec` is installed but the JBIG2 payload is invalid, decode failure used to reach the caller as a bare `RuntimeError("qpdf will consume this exception")` plus an unraisable traceback on stderr.

This change:

- Wraps `jbig2dec` `CalledProcessError` as `DataDecodingError`, including stderr from the decoder
- Throws `std::runtime_error("Pl_JBIG2: …")` from the C++ pipeline instead of writing an unraisable exception, so the existing translator maps it to `DataDecodingError` like `Pl_Flate` / `Pl_DCT`
- Remaps qpdf's generic "unfilterable stream" error to `DataDecodingError` when the decoder is present (missing decoder still raises `DependencyError`)

Fixes #735

## Test plan

- [x] `test_decode_jbig2_wraps_called_process_error` — Python wrapper includes decoder stderr
- [x] `test_jbig2_error` / `test_jbig2_reports_no_version` — patched decoder failures raise `DataDecodingError`, no unraisable
- [x] `test_jbig2_invalid_payload_is_data_decoding_error` — owner repro from #735 (`Pdf.new()` + invalid JBIG2 stream)
- [ ] CI: `uv run pytest tests/test_jbig2.py tests/test_errors.py`