### PR TITLE
fix: make DataDecodingError a subclass of PdfError

### DIFF
--- a/docs/releasenotes/version10.md
+++ b/docs/releasenotes/version10.md
@@ -14,6 +14,12 @@ free-threaded use required building from source. As always, coordinating
 concurrent modification of the same object across threads requires a lock -- see
 the architecture notes on thread safety.
 
+## v10.12.2
+
+- `DataDecodingError` is now a subclass of `PdfError`, so `except PdfError`
+  also catches undecodable streams. Existing `except DataDecodingError`
+  handlers continue to work unchanged. {issue}`739`
+
 ## v10.12.1
 
 - `pikepdf.StreamParser` is now exported from the top-level package and included

--- a/src/core/pikepdf.cpp
+++ b/src/core/pikepdf.cpp
@@ -333,19 +333,24 @@ NB_MODULE(_core, m)
         PyErr_NewException("pikepdf._core.ReferenceCycleError",
             exc_main.load(std::memory_order_acquire),
             nullptr));
-    // PasswordError and DataDecodingError are siblings of PdfError (both
-    // direct subclasses of Exception), not subclasses of it. Reflect the
-    // documented hierarchy from src/pikepdf/_core.pyi and the pre-nanobind
-    // behavior; downstream code (e.g. ocrmypdf) relies on `except PdfError`
-    // not catching PasswordError.
+    // PasswordError is a sibling of PdfError (a direct subclass of
+    // Exception), not a subclass of it. Reflect the documented hierarchy
+    // from src/pikepdf/_core.pyi and the pre-nanobind behavior; downstream
+    // code (e.g. ocrmypdf) relies on `except PdfError` not catching
+    // PasswordError.
     publish(exc_password,
         m,
         "PasswordError",
         PyErr_NewException("pikepdf._core.PasswordError", nullptr, nullptr));
+    // DataDecodingError is a subclass of PdfError, so existing `except PdfError`
+    // handlers keep catching undecodable streams. Published after exc_main so
+    // PdfError exists to serve as the base class.
     publish(exc_datadecoding,
         m,
         "DataDecodingError",
-        PyErr_NewException("pikepdf._core.DataDecodingError", nullptr, nullptr));
+        PyErr_NewException("pikepdf._core.DataDecodingError",
+            exc_main.load(std::memory_order_acquire),
+            nullptr));
     publish(exc_usage,
         m,
         "JobUsageError",

--- a/src/pikepdf/_core.pyi
+++ b/src/pikepdf/_core.pyi
@@ -85,9 +85,6 @@ class _NamePath(NamePath):
 
 # Exceptions
 
-class DataDecodingError(Exception):
-    """Exception thrown when a stream object in a PDF cannot be decoded."""
-
 class JobUsageError(Exception):
     """Exception thrown when the pikepdf.Job interface is used incorrectly."""
 
@@ -96,6 +93,9 @@ class PasswordError(Exception):
 
 class PdfError(Exception):
     """General pikepdf-specific exception."""
+
+class DataDecodingError(PdfError):
+    """Exception thrown when a stream object in a PDF cannot be decoded."""
 
 class ReferenceCycleError(PdfError):
     """When a direct (non-indirect) object would be made to contain itself.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -55,6 +55,28 @@ def test_data_decoding_errors(filter_: str, data: bytes, msg: str):
 
 
 @pytest.mark.abi3_smoke
+def test_data_decoding_error_is_pdf_error_subclass():
+    # Regression test for #739: DataDecodingError must be a PdfError subclass,
+    # so `except PdfError` catches undecodable streams.
+    assert issubclass(DataDecodingError, PdfError)
+
+
+@pytest.mark.abi3_smoke
+def test_except_pdf_error_catches_data_decoding_error():
+    # The issue's exact scenario: a handler written as `except PdfError`
+    # must catch a DataDecodingError raised from read_bytes().
+    p = Pdf.new()
+    st = Stream(p, b'\xba\xad', Filter=Name('/FlateDecode'))
+    caught = None
+    try:
+        st.read_bytes()
+    except PdfError as e:
+        caught = e
+    assert caught is not None
+    assert isinstance(caught, DataDecodingError)
+
+
+@pytest.mark.abi3_smoke
 def test_system_error():
     with pytest.raises(FileNotFoundError):
         pikepdf._core._test.fopen_nonexistent_file()


### PR DESCRIPTION
## Summary

`DataDecodingError` is now a subclass of `PdfError`. Previously it derived directly from `Exception`, so code that caught `PdfError` around `read_bytes()` silently missed undecodable streams — a damaged stream with a bad `/Filter` escaped the natural handler. Now `except PdfError` catches decode failures too, while existing `except DataDecodingError` handlers keep working unchanged.

`PasswordError` remains a sibling of `PdfError` (the ocrmypdf contract that `except PdfError` must not catch it is preserved). `ReferenceCycleError` is unchanged.

Fixes #739
